### PR TITLE
Fix debug macros in SNTP.

### DIFF
--- a/examples/01.SNTP/xmake.lua
+++ b/examples/01.SNTP/xmake.lua
@@ -29,6 +29,8 @@ compartment("sntp_example")
 firmware("01.sntp_example")
   set_policy("build.warning", true)
   add_deps("TCPIP", "Firewall", "NetAPI", "SNTP", "sntp_example", "atomic8", "time_helpers", "debug")
+  -- stdio only needed for debug prints in SNTP, can be removed with --debug-sntp=n
+  add_deps("stdio")
   on_load(function(target)
     target:values_set("board", "$(board)")
     target:values_set("threads", {

--- a/lib/sntp/core_sntp_config.h
+++ b/lib/sntp/core_sntp_config.h
@@ -1,31 +1,27 @@
-#ifdef DEBUG_SNTP
-#	define PrintfError(...)                                                   \
-		printf("Error: "__VA_ARGS__);                                          \
-		printf("\n")
-#	define PrintfWarn(...)                                                    \
-		printf("Warn: "__VA_ARGS__);                                           \
-		printf("\n")
-#	define PrintfInfo(...)                                                    \
-		printf("Info: " __VA_ARGS__);                                          \
-		printf("\n")
-#	define PrintfDebug(...)                                                   \
-		printf("Debug: " __VA_ARGS__);                                         \
-		printf("\n")
+#ifndef DEBUG_SNTP
+#	define DEBUG_SNTP false
+#endif
+
+#if DEBUG_SNTP
+#	include <stdio.h>
+
+/**
+ * coreSNTP calls the logging macros with parameters wrapped in double
+ * parentheses, which explains why we need an indirection (`LogError` redirects
+ * to `LogFunction`) and call the second printf without parentheses.
+ */
+#	define LogFunction(LEVEL, ...)                                            \
+		printf(LEVEL);                                                         \
+		printf __VA_ARGS__;                                                    \
+		printf("\n");
 #else
-#	define PrintfError(...)                                                   \
-		do                                                                     \
-		{                                                                      \
-		} while (0)
-#	define PrintfWarn(...)                                                    \
-		do                                                                     \
-		{                                                                      \
-		} while (0)
-#	define PrintfInfo(...)                                                    \
-		do                                                                     \
-		{                                                                      \
-		} while (0)
-#	define PrintfDebug(...)                                                   \
+#	define LogFunction(LEVEL, ...)                                            \
 		do                                                                     \
 		{                                                                      \
 		} while (0)
 #endif
+
+#define LogError(...) LogFunction("SNTP Error: ", __VA_ARGS__);
+#define LogWarn(...) LogFunction("SNTP Warn: ", __VA_ARGS__);
+#define LogInfo(...) LogFunction("SNTP Info: ", __VA_ARGS__);
+#define LogDebug(...) LogFunction("SNTP Debug: ", __VA_ARGS__);

--- a/lib/sntp/xmake.lua
+++ b/lib/sntp/xmake.lua
@@ -3,7 +3,10 @@ library("time_helpers")
   add_includedirs("../../include")
   add_files("time-helpers.cc")
 
+debugOption("SNTP")
+
 compartment("SNTP")
+  add_rules("cheriot.component-debug")
   set_default(false)
   add_deps("freestanding", "NetAPI")
   add_files("sntp.cc")
@@ -11,4 +14,3 @@ compartment("SNTP")
   add_defines("CHERIOT_CUSTOM_DEFAULT_MALLOC_CAPABILITY")
   add_files("../../third_party/coreSNTP/source/core_sntp_client.c",
             "../../third_party/coreSNTP/source/core_sntp_serializer.c")
-


### PR DESCRIPTION
It should be `Log...`, not `Printf...`

Expose a debug option while we are at it.