### PR TITLE
Remove the allocator from the mqtt compartment.

### DIFF
--- a/lib/mqtt/mqtt.cc
+++ b/lib/mqtt/mqtt.cc
@@ -1,13 +1,8 @@
 // Copyright SCI Semiconductor and CHERIoT Contributors.
 // SPDX-License-Identifier: MIT
 
-#include <FreeRTOS-Compat/FreeRTOS.h>
-#include <cheri.hh>
-
-// Uncomment for useful debugging message on CHERI faults.
-//#include <fail-simulator-on-error.h>
-
 #include <NetAPI.h>
+#include <cheri.hh>
 #include <core_mqtt.h>
 #include <debug.hh>
 #include <locks.hh>
@@ -27,11 +22,6 @@ constexpr bool DebugMQTT =
   ;
 
 using Debug = ConditionalDebug<DebugMQTT, "MQTT Client">;
-
-// TODO Ultimately it would be nice to remove this entirely and perform all
-// allocations with the caller's capabilities. We need to determine if coreMQTT
-// supports this.
-DEFINE_ALLOCATOR_CAPABILITY(__default_malloc_capability, 16 * 1024)
 
 struct NetworkContext
 {

--- a/lib/mqtt/xmake.lua
+++ b/lib/mqtt/xmake.lua
@@ -8,9 +8,9 @@ compartment("MQTT")
   set_default(false)
   add_deps("freestanding", "NetAPI", "TLS")
   add_files("mqtt.cc")
+  add_defines("CHERIOT_NO_AMBIENT_MALLOC", "CHERIOT_NO_NEW_DELETE")
   add_includedirs(".", "../../include", "../../third_party/coreMQTT/source/include",
                                         "../../third_party/coreMQTT/source/interface")
-  add_defines("CHERIOT_CUSTOM_DEFAULT_MALLOC_CAPABILITY")
   add_files("../../third_party/coreMQTT/source/core_mqtt.c",
             "../../third_party/coreMQTT/source/core_mqtt_serializer.c",
             "../../third_party/coreMQTT/source/core_mqtt_state.c")


### PR DESCRIPTION
After checking, the allocator is actually not needed for this compartment. Remove the malloc capability from the compartment, and remove new and delete like we did previously for TLS.