### PR TITLE
Fix double free/unclaim in `network_socket_close`.

### DIFF
--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -483,9 +483,6 @@ int network_socket_close(Timeout *t, SObj mallocCapability, SObj sealedSocket)
 		  // Close the socket.  Another thread will actually clean up the
 		  // memory.
 		  FreeRTOS_closesocket(socket->socket);
-		  // Drop the caller's claim on the socket.  The TCP/IP stack retains a
-		  // claim.
-		  heap_free(mallocCapability, socket->socket);
 		  token_obj_destroy(mallocCapability, socket_key(), sealedSocket);
 		  return 0;
 	  },


### PR DESCRIPTION
We call `heap_free` on the socket early in the function, bailing out if it failed. Then we call it a second time right at the end before destroying the token. This was introduced as part of e4ea2b2fc9e49e8f51d4b1e4985d4c68b6c7648d.

We can safely remove this line as the heap_free was done earlier.