### PR TITLE
Fix free of offset-ed network buffer.

### DIFF
--- a/lib/tcpip/BufferManagement.cc
+++ b/lib/tcpip/BufferManagement.cc
@@ -93,11 +93,21 @@ void vReleaseNetworkBufferAndDescriptor(
 {
 	if (pxNetworkBuffer != nullptr)
 	{
+		uint8_t *bufferWithoutOffset =
+		  pxNetworkBuffer->pucEthernetBuffer - ipBUFFER_PADDING;
+
 		Debug::log("Freeing descriptor: {} and buffer {}",
 		           pxNetworkBuffer,
-		           pxNetworkBuffer->pucEthernetBuffer);
-		free(pxNetworkBuffer->pucEthernetBuffer);
-		free(pxNetworkBuffer);
+		           bufferWithoutOffset);
+
+		int ret = heap_free(MALLOC_CAPABILITY, bufferWithoutOffset);
+		ret |= heap_free(MALLOC_CAPABILITY, pxNetworkBuffer);
+
+		if (ret != 0)
+		{
+			// This is not supposed to happen.
+			Debug::log("Failed to free network buffer or descriptor.");
+		}
 	}
 }
 


### PR DESCRIPTION
Network buffers are allocated in `pxGetNetworkBufferWithDescriptor` with `heap_allocate(_, MALLOC_CAPABILITY, _)` and offset-ed with `ipBUFFER_PADDING`. Later on, buffers are freed in `vReleaseNetworkBufferAndDescriptor` with `free`.

Before freeing the buffer, we should remove the `ipBUFFER_PADDING` offset. Although passing an offset-ed buffer to `free` may work in practice, it is a bit wobbly.

For consistency with the allocation site above, we should also use `heap_free` with `MALLOC_CAPABILITY` instead of `free`. Although both are equivalent, this makes the code look a little bit more correct.

Lastly, it would be nice to check the result of `heap_free` and output a debug message in case of failure. Any failure here will nearly always result in OOM, which can be tricky to debug.

**Illustration of the results**

Before the PR, running the MQTT example with logging enabled in the buffer manager gives the following addresses allocated and freed:
```
$ cat /tmp/logs_mqtt_before_PR.log | grep -Po "buffer[: ]+0x[0-9a-f]*" | grep -Po "0x[0-9a-f]+" | sort | uniq -c
      4 0x200735c0
      4 0x200735ce
      1 0x20073628
      1 0x20073636
      1 0x20073708
      1 0x20073716
      1 0x200738c0
      1 0x200738ce
      1 0x20073a98
      1 0x20073aa6
      1 0x20073c50
      1 0x20073c5e
      4 0x20073c78
      4 0x20073c86
      1 0x20073ce0
      1 0x20073cee
      1 0x20073cf0
      1 0x20073cfe
      1 0x20073d40
      1 0x20073d48
      1 0x20073d4e
      1 0x20073d56
      1 0x20073d58
      1 0x20073d66
      1 0x20073d90
      1 0x20073d9e
      2 0x20073db8
      2 0x20073dc6
      3 0x20073e20
      1 0x20073e28
      3 0x20073e2e
      1 0x20073e36
      2 0x20073f00
      2 0x20073f0e
      1 0x200740b0
      1 0x200740be
      1 0x20074118
      1 0x20074126
      1 0x20074180
      1 0x2007418e
      1 0x200741e0
      1 0x200741ee
      1 0x200742a8
      1 0x200742b6
      1 0x20074370
      1 0x2007437e
      1 0x20074438
      1 0x20074446
      1 0x200746b8
      1 0x200746c6
      4 0x20074720
      4 0x2007472e
      1 0x20074730
      1 0x2007473e
      1 0x20074798
      1 0x200747a6
      1 0x200747f8
      2 0x20074800
      1 0x20074806
      2 0x2007480e
      2 0x20074810
      2 0x2007481e
      1 0x20074f68
      1 0x20074f76
      1 0x20074fd0
      2 0x20074fd8
      1 0x20074fde
      2 0x20074fe6
      1 0x20075020
      1 0x2007502e
      2 0x20075040
      2 0x2007504e
      1 0x20075098
      1 0x200750a6
      2 0x200750b0
      2 0x200750be
      1 0x20075108
      1 0x20075116
      2 0x20075120
      2 0x2007512e
      1 0x20075180
      1 0x2007518e
      1 0x20075198
      1 0x200751a6
      2 0x2007be88
      2 0x2007be96
      5 0x2007bef0
      5 0x2007befe
```

All addresses with an odd number in front are either 1) only allocated and not freed, or 2) only freed but not allocated. This is what concerned me initially and what prompted me to investigate this bug.

After the PR, we get this:
```
$ cat /tmp/logs_mqtt_after_PR | grep -Po "buffer[: ]+0x[0-9a-f]*" | grep -Po "0x[0-9a-f]+" | sort | uniq -c
      8 0x200735c0
      2 0x20073628
      2 0x20073708
      2 0x200738c0
      2 0x20073a98
      2 0x20073c50
      8 0x20073c78
      2 0x20073ce0
      2 0x20073cf0
      2 0x20073d40
      2 0x20073d48
      2 0x20073d58
      4 0x20073db8
      6 0x20073e20
      2 0x20073e28
      2 0x20073e70
      4 0x20073f00
      2 0x200740b0
      2 0x20074118
      2 0x20074180
      2 0x200741e0
      2 0x200742a8
      2 0x20074370
      2 0x20074478
      2 0x200746b8
      8 0x20074720
      2 0x20074730
      2 0x20074798
      2 0x200747f8
      4 0x20074800
      4 0x20074810
      2 0x20074f68
      2 0x20074fd0
      4 0x20074fd8
      4 0x20075040
      2 0x20075098
      4 0x200750b0
      2 0x20075108
      4 0x20075120
      2 0x20075180
      2 0x20075198
      4 0x2007be88
     10 0x2007bef0
```

The situation is now as expected: every address is seen in pair (one allocation, one free).

Note: the logs we are parsing here look like this:
```
Buffer management: Allocated 0x138 byte buffer: 0x20073708 (v:1 0x20073708-0x20073850 l:0x148
 o:0x0 p: G RWcgm- -- ---), descriptor: 0x200736a0 (v:1 0x200736a0-0x20073700 l:0x60 o:0x0 p:
 G RWcgm- -- ---)                                                                            
Buffer management: Freeing descriptor: 0x200736a0 (v:1 0x200736a0-0x20073700 l:0x60 o:0x0 p: 
G RWcgm- -- ---) and buffer 0x20073708 (v:1 0x20073708-0x20073850 l:0x148 o:0x0 p: G RWcgm- -
- ---)
```

We are matching `buffer: 0x20073708` in the allocation log entry and `buffer 0x20073708` in the free log entry.