### PR TITLE
Fix `FreeRTOS_connect` return value handling.

### DIFF
--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -496,7 +496,8 @@ int network_socket_connect_tcp_internal(Timeout       *timeout,
 		  {
 			  default:
 				  return -EINVAL;
-			  case 0:
+			  case 0: // success
+			  case -pdFREERTOS_ERRNO_EISCONN: // already connected
 				  Debug::log("Successfully connected to server");
 				  return 0;
 			  case -pdFREERTOS_ERRNO_EWOULDBLOCK:


### PR DESCRIPTION
`-pdFREERTOS_ERRNO_EISCONN` actually means success, so we should consider it like 0 when processing the return value (instead of returning `-EINVAL`.

This fix was initially proposed by David in an experimental branch.

While at it, put the `default` block at the end because it is the least likely to execute (vast majority of cases will be success or timeout).