### PR TITLE
Fix memory leak in `host_resolve`.

### DIFF
--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -205,6 +205,7 @@ namespace
 		                       &results);
 		if (ret != 0)
 		{
+			// Try with IPv4 if the lookup failed with IPv6
 			if (useIPv6)
 			{
 				return host_resolve(hostname, false);
@@ -237,6 +238,8 @@ namespace
 				           (int)r->ai_addr->sin_address.ulIP_IPv4 >> 24 & 0xff);
 			}
 		}
+
+		FreeRTOS_freeaddrinfo(results);
 		return address;
 	}
 


### PR DESCRIPTION
We never free the `freertos_addrinfo` we get from `FreeRTOS_getaddrinfo`. Although this is not documented in the FreeRTOS API reference, this buffer should be freed via `FreeRTOS_freeaddrinfo`.

This is a pretty large allocation (328B), which explains why we run out of memory quickly when doing connects/disconnects in a loop.