### PR TITLE
Add missing checks to the firewall and TCP/IP stack.

### DIFF
--- a/lib/firewall/firewall.cc
+++ b/lib/firewall/firewall.cc
@@ -488,6 +488,9 @@ bool ethernet_driver_start()
 
 bool ethernet_send_frame(uint8_t *frame, size_t length)
 {
+	// We do not check the frame and length here, because we do not use it
+	// in the firewall (we pass it on to untouched to the driver). We
+	// consider it the driver's job to check the pointer before using it.
 	LockGuard g{sendLock};
 	auto     &ethernet = lazy_network_interface();
 	return ethernet.send_frame(frame, length, packet_filter_egress);

--- a/lib/tcpip/driver_adaptor.cc
+++ b/lib/tcpip/driver_adaptor.cc
@@ -68,6 +68,10 @@ namespace
 bool __cheri_compartment("TCPIP")
   ethernet_receive_frame(uint8_t *frame, size_t length)
 {
+	// We do not check the frame pointer and length because this function
+	// can only be called by the firewall and we trust the firewall. See
+	// the compartment call allow list entry of `ethernet_send_frame` in
+	// the policy file (`network_stack.rego`).
 	if (eConsiderFrameForProcessing(frame) != eProcessBuffer)
 	{
 		// Debug::log("Frame not for us");


### PR DESCRIPTION
Add two missing checks to validate incoming frames.