### PR TITLE
Fix bugs in `network_socket_receive_from`.

### DIFF
--- a/include/NetAPI.h
+++ b/include/NetAPI.h
@@ -180,8 +180,13 @@ int __cheri_compartment("TCPIP")
  * The `bytesReceived` field of the result will be negative if an error
  * occurred.  The `buffer` field will be null if no data were received.
  *
+ * Note that errors occuring in this function (particularly timeout and invalid
+ * `address` or `port` pointers) may cause UDP packets to be dropped.
+ *
  * The negative values will be errno values:
  *
+ *  - `-ENOMEM`: The allocation quota is insufficient to hold the packet.
+ *  - `-EPERM`: The `address` and/or `port` pointers are invalid.
  *  - `-EINVAL`: The socket is not valid.
  *  - `-ETIMEDOUT`: The timeout was reached before data could be received.
  *  - `-ENOTCONN`: The socket is not connected.


### PR DESCRIPTION
A few things are wrong with `network_socket_receive_from`:

- We claim `unclaimedBuffer` but don't unclaim it on error paths, thus leaking the buffer.
- The `check_pointer` for `port` is done on `address`, likely due to a copy/paste issue.
- The `if (received > 0)` before setting `buffer` is redundant as we already checked this a few lines earlier.
- We don't document that the UDP packet will be dropped if an error occurs in this function (timeout, permissions, etc.).
- The documentation of error codes is incomplete.

Address all these issues.