### PR TITLE
Rework `network_socket_close` error paths.

### DIFF
--- a/include/NetAPI.h
+++ b/include/NetAPI.h
@@ -102,9 +102,15 @@ NetworkAddress __cheri_compartment("NetAPI")
  *
  * Returns 0 on success, or a negative error code on failure:
  *
- *  - -EINVAL: The socket is not valid or the malloc capability does not match
- *    the socket.
- *  - -ETIMEDOUT: The timeout was reached before the socket could be closed.
+ *  - -EINVAL: Invalid argument (the socket is not valid, the malloc capability
+ *             does not match the socket, or the timeout is invalid). When
+ *             -EINVAL is returned, no resources were freed and the socket was
+ *             not closed. The operation can be retried with correct arguments.
+ *  - -ETIMEDOUT: The timeout was reached before the socket could be closed. No
+ *             resources were freed and the socket was not closed. The operation
+ *             can be retried.
+ *  - -ENOTRECOVERABLE: An error occurred and the socket was partially freed or
+ *             closed. The operation cannot be retried.
  */
 int __cheri_compartment("TCPIP")
   network_socket_close(Timeout *t, SObj mallocCapability, SObj sealedSocket);


### PR DESCRIPTION
49f42c1e1f7fcbacace0bcd52a58f98013168616 forgot to add unlocks on error paths in `network_socket_close`. Address this.

At the same time, clarify that we have two types of errors here: those where the call can be retried (e.g., called with the wrong malloc capability, or an invalid timeout), and those which cannot be retried (the socket close failed due to an unspecified error and we went ahead to free it). Both are currently under `-EAGAIN`. I think that we should differentiate the two to give a chance to the caller to call again with the right arguments. Address this by moving unrecoverable errors to `-ENOTRECOVERABLE` and update the documentation accordingly.

Finally, a socket close return value of 0 is unrecoverable and most likely due to an internal error, so in that case we should go ahead and free everything instead of returning `-EAGAIN`.

**Note**: Since all errors currently under `-ENOTRECOVERABLE` are internal, not supposed to happen (modulo bug), and not acted upon (we're leaking memory, but there really isn't anything we can do about that apart from maybe reseting, once we have it working?), we could also simply move them as debug asserts and ignore the failure.