### PR TITLE
Better handle TCP/IP stack crashes in the TLS compartment.

### DIFF
--- a/include/NetAPI.h
+++ b/include/NetAPI.h
@@ -163,6 +163,7 @@ NetworkReceiveResult __cheri_compartment("TCPIP")
  *
  * The negative values will be errno values:
  *
+ *  - `-EPERM`: `buffer` and/or `length` are invalid.
  *  - `-EINVAL`: The socket is not valid.
  *  - `-ETIMEDOUT`: The timeout was reached before data could be received.
  *  - `-ENOTCONN`: The socket is not connected.


### PR DESCRIPTION
When the TCP/IP stack crashes, API calls to the compartment return `-ECOMPARTMENTFAIL`. These should be treated similarly to `-ENOTCONN`.

Currently `-ECOMPARTMENTFAIL` failures are not considered by the TLS compartment and are handled in various (incorrect) ways across the code-base. Address this.

While we are at it, avoid the call to `network_socket_close` if the socket is a `nullptr`.