### PR TITLE
Better handle TCP/IP stack crashes in the NETAPI compartment.

### DIFF
--- a/lib/tcpip/network-internal.h
+++ b/lib/tcpip/network-internal.h
@@ -17,9 +17,15 @@
  * Resolve a host name to an IPv4 or IPv6 address.  If `useIPv6` is true, then
  * this will first attempt to find a IPv6 address and fall back to IPv4 if none
  * is found.
+ *
+ * The result of the resolve is stored in `outAddress`.
+ *
+ * This returns zero for success, or a negative value on error.
  */
-NetworkAddress __cheri_compartment("TCPIP")
-  network_host_resolve(const char *hostname, bool useIPv6);
+__cheri_compartment("TCPIP") int network_host_resolve(
+  const char     *hostname,
+  bool            useIPv6,
+  NetworkAddress *outAddress);
 
 /**
  * Create a socket and bind it to the given address.  The socket will be
@@ -72,6 +78,9 @@ struct SocketKind
 };
 
 /**
- * Returns information about the given socket.
+ * Returns information about the given socket in `kind`.
+ *
+ * This returns zero for success, or a negative value on error.
  */
-SocketKind __cheri_compartment("TCPIP") network_socket_kind(SObj socket);
+int __cheri_compartment("TCPIP")
+  network_socket_kind(SObj socket, SocketKind *kind);


### PR DESCRIPTION
When the TCP/IP stack crashes, API calls to the compartment return `-ECOMPARTMENTFAIL`.

Currently `-ECOMPARTMENTFAIL` failures are not considered by the NetAPI compartment. This leads to erratic behavior when the network stack crashes, such as adding nonsensical entries to the firewall.

Address this with proper checking.