### PR TITLE
Convert heap_allocate null pointer checks to valid tag checks.

### DIFF
--- a/lib/tcpip/BufferManagement.cc
+++ b/lib/tcpip/BufferManagement.cc
@@ -10,6 +10,8 @@
 
 using Debug = ConditionalDebug<false, "Buffer management">;
 
+using CHERI::Capability;
+
 // Use a separate allocator quota for the buffer manager (false by default).
 // The buffer manager is responsible for allocating network buffers, which
 // differs from the other types of allocations the TCP/IP stack performs. It
@@ -77,14 +79,14 @@ pxGetNetworkBufferWithDescriptor(size_t     xRequestedSizeBytes,
 	  static_cast<NetworkBufferDescriptor_t *>(heap_allocate(
 	    &t, BM_MALLOC_CAPABILITY, sizeof(NetworkBufferDescriptor_t))),
 	  deleter};
-	if (descriptor == nullptr)
+	if (!Capability{descriptor.get()}.is_valid())
 	{
 		Debug::log("Failed to allocate descriptor");
 		return nullptr;
 	}
 	auto *buffer = static_cast<uint8_t *>(heap_allocate(
 	  &t, BM_MALLOC_CAPABILITY, xRequestedSizeBytes + ipBUFFER_PADDING));
-	if (buffer == nullptr)
+	if (!Capability{buffer}.is_valid())
 	{
 		Debug::log("Failed to allocate {} byte buffer", xRequestedSizeBytes);
 		return nullptr;

--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -796,7 +796,7 @@ NetworkReceiveResult network_socket_receive(Timeout *timeout,
               buffer = static_cast<uint8_t *>(
                 heap_allocate(&zeroTimeout, mallocCapability, available));
               timeout->elapse(zeroTimeout.elapsed);
-              if (buffer == nullptr)
+              if (!Capability{buffer}.is_valid())
               {
                   // If there's a lot of data, just try a small
                   // allocation and see if that works.
@@ -825,7 +825,7 @@ NetworkReceiveResult network_socket_receive(Timeout *timeout,
                   available = -ENOMEM;
                   return nullptr;
               }
-          } while (buffer == nullptr);
+          } while (!Capability{buffer}.is_valid());
           return buffer;
 	   },
 	   [&](void *buffer) -> void { heap_free(mallocCapability, buffer); });

--- a/lib/tls/tls.cc
+++ b/lib/tls/tls.cc
@@ -414,7 +414,7 @@ SObj tls_connection_create(Timeout                    *t,
 	  static_cast<br_ssl_client_context *>(
 	    heap_allocate(t, allocator, sizeof(br_ssl_client_context))),
 	  deleter};
-	if (clientContext == nullptr)
+	if (!Capability{clientContext.get()}.is_valid())
 	{
 		Debug::log("Failed to allocate client context");
 		return nullptr;
@@ -424,7 +424,7 @@ SObj tls_connection_create(Timeout                    *t,
 	    heap_allocate(t, allocator, sizeof(br_x509_minimal_context))),
 	  deleter};
 	auto *engine = &clientContext->eng;
-	if (x509Context == nullptr)
+	if (!Capability{x509Context.get()}.is_valid())
 	{
 		Debug::log("Failed to allocate X509 context");
 		return nullptr;
@@ -442,7 +442,8 @@ SObj tls_connection_create(Timeout                    *t,
 	  static_cast<unsigned char *>(
 	    heap_allocate(t, allocator, MinimumBufferSize)),
 	  deleter};
-	if (iobufIn == nullptr || iobufOut == nullptr)
+	if (!Capability{iobufIn.get()}.is_valid() ||
+	    !Capability{iobufOut.get()}.is_valid())
 	{
 		Debug::log("Failed to allocate buffers");
 		return nullptr;
@@ -638,7 +639,7 @@ NetworkReceiveResult tls_connection_receive(Timeout *t, SObj sealedConnection)
                 heap_allocate(&zeroTimeout, mallocCapability, available));
               t->elapse(zeroTimeout.elapsed);
 
-              if (buffer == nullptr)
+              if (!Capability{buffer}.is_valid())
               {
                   // If there's a lot of data, just try a small
                   // allocation and see if that works.
@@ -667,7 +668,7 @@ NetworkReceiveResult tls_connection_receive(Timeout *t, SObj sealedConnection)
                   available = -ENOMEM;
                   return nullptr;
               }
-          } while (buffer == nullptr);
+          } while (!Capability{buffer}.is_valid());
           return buffer;
 	   });
 	return {result, buffer};


### PR DESCRIPTION
Pointers returned by `heap_allocate` should be checked for validity through the tag bit, not by comparing them with `nullptr`. Here we use the C low-level builtin instead of the C++ `Capability` API to limit the amount of refactoring needed.

Go through all allocation sites of the repository and update where needed.

This does the same as b35d1d944fd9038b0c821e9e51d2b6822dcc8cf8 in the main tree.