### PR TITLE
Restart the TCP/IP stack on crash.

### DIFF
--- a/lib/netapi/NetAPI.cc
+++ b/lib/netapi/NetAPI.cc
@@ -1,7 +1,7 @@
 // Copyright SCI Semiconductor and CHERIoT Contributors.
 // SPDX-License-Identifier: MIT
 
-#include "../firewall/firewall.h"
+#include "../firewall/firewall.hh"
 #include "../tcpip/network-internal.h"
 #include <NetAPI.h>
 

--- a/lib/tcpip/BufferManagement.hh
+++ b/lib/tcpip/BufferManagement.hh
@@ -1,0 +1,31 @@
+// Copyright SCI Semiconductor and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+/**
+ * Internal helpers and configuration settings for use in the TCP/IP buffer
+ * manager. These should be called or used only from/in the TCP/IP compartment.
+ */
+
+#ifndef USE_DEDICATED_BUFFERMANAGER_POOL
+// Use a separate allocator quota for the buffer manager (false by default).
+// The buffer manager is responsible for allocating network buffers, which
+// differs from the other types of allocations the TCP/IP stack performs. It
+// may thus make sense to give it its own quota. We may want to expose this as
+// a build system configuration option at some point.
+#	define USE_DEDICATED_BUFFERMANAGER_POOL false
+#endif
+
+#if USE_DEDICATED_BUFFERMANAGER_POOL
+extern void free_buffer_manager_memory();
+#else
+/**
+ * Free the buffer manager's memory. Since the buffer manager does not have a
+ * dedicated quota, this is a noop.
+ */
+static inline void free_buffer_manager_memory()
+{
+	return;
+}
+#endif

--- a/lib/tcpip/FreeRTOSIPConfig.h
+++ b/lib/tcpip/FreeRTOSIPConfig.h
@@ -33,6 +33,28 @@
 #define configMINIMAL_STACK_SIZE 128
 
 /**
+ * FreeRTOS+TCP uses descriptors to track information about the packets in a
+ * window. A pool of descriptors is allocated when the first TCP connection is
+ * made. This configuration entry sets the size of the pool.
+ *
+ * In the worst case, each TCP connection will have an Rx and Tx window of at
+ * most 8 segments (according to the FreeRTOS+TCP documentation), requiring 16
+ * descriptors in total per TCP connection. This configuration entry should
+ * thus be set to `(expected maximum number of TCP connections) x 16`.
+ *
+ * If we assume at most 6 TCP connections, this results in 96 segments.
+ *
+ * Each descriptor is 104 bytes, i.e., set to 96 this results in a memory
+ * footprint of 9,984 bytes.
+ *
+ * Note that the pool of descriptors is reallocated at every network stack
+ * reset. Setting this number to a large value (e.g., 256, the FreeRTOS+TCP
+ * default) is known to cause reset failures due to fragmentation preventing us
+ * from reallocating the pool.
+ */
+#define ipconfigTCP_WIN_SEG_COUNT 96
+
+/**
  * Enable counting semaphore functionality in the build, as this is necessary
  * to build FreeRTOS+TCP.
  */
@@ -62,7 +84,6 @@
 #define ipconfigREPLY_TO_INCOMING_PINGS 1
 
 #define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS 8
-
 
 #define ipconfigTCP_RX_BUFFER_LENGTH ( 1280 )
 #define ipconfigTCP_TX_BUFFER_LENGTH ( 1280 )
@@ -97,3 +118,10 @@
 
 #define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND 0
 #define ipconfigUSE_NETWORK_EVENT_HOOK 1
+
+// Necessary to have FreeRTOS+TCP invoke our own `ipFOREVER` function.  As of
+// FreeRTOS+TCP 3.1.0 this only enables external `ipFOREVER`. It would be nice
+// to upstream a patch to have this variable renamed into something specific to
+// `ipFOREVER` to ensure that we do not enable additional undesired options in
+// future releases.
+#define TEST

--- a/lib/tcpip/FreeRTOS_IP_wrapper.c
+++ b/lib/tcpip/FreeRTOS_IP_wrapper.c
@@ -3,12 +3,38 @@
 #undef xTaskCreate
 #define xTaskCreate(...) (ip_thread_start(), pdPASS)
 void ip_thread_start(void);
+
+// These C files are included here so that we can edit their static globals.
+// This is evil.
+#include "../../third_party/freertos-plus-tcp/source/FreeRTOS_ARP.c"
+#include "../../third_party/freertos-plus-tcp/source/FreeRTOS_DHCP.c"
+#include "../../third_party/freertos-plus-tcp/source/FreeRTOS_DNS_Cache.c"
 #include "../../third_party/freertos-plus-tcp/source/FreeRTOS_IP.c"
+#include "../../third_party/freertos-plus-tcp/source/FreeRTOS_IP_Timers.c"
+#include "../../third_party/freertos-plus-tcp/source/FreeRTOS_TCP_IP.c"
+#include "../../third_party/freertos-plus-tcp/source/FreeRTOS_TCP_WIN.c"
+
 #include <futex.h>
 #include <locks.h>
 #include <stdatomic.h>
 
-uint32_t threadEntryGuard;
+/**
+ * Flag used to synchronize the network stack thread and user threads at
+ * startup.
+ *
+ * This should not be reset by the error handler and is reset-critical.
+ *
+ * Note (which also applies to other reset-critical data): ultimately we should
+ * move this to a separate "network stack TCB" compartment to be able to reset
+ * all the state of this compartment unconditionally by re-zeroing the BSS and
+ * resetting .data from snapshots.
+ */
+static uint32_t threadEntryGuard;
+
+/**
+ * Store the thread ID of the TCP/IP thread for use in the error handler.
+ */
+uint16_t networkThreadID;
 
 /**
  * Global lock acquired by the IP thread at startup time. This lock is never
@@ -26,18 +52,98 @@ void ip_thread_start(void)
 	futex_wake(&threadEntryGuard, 1);
 }
 
+/**
+ * Cleanup to perform when restarting the network stack, including resetting
+ * global state.
+ *
+ * This must be here as most of this state is static (we can edit them here
+ * through the evil "include C files" hack above).
+ *
+ * This global state was identified by going through all entries of the .bss
+ * and .data sections of this compartment. This *will* break if new FreeRTOS
+ * releases introduce new global state. Ideally we would later reset all this
+ * state automatically by zero-ing the entire .bss and resetting .data with
+ * snapshots taken at startup time. See note of `defaultUDPPacketHeaderCopy`.
+ */
+void ip_cleanup(void)
+{
+	/// Reset data from `.bss`
+
+	xIPTaskInitialised = 0;
+
+	// Timers to reset
+	memset(&xARPTimer, 0, sizeof(xARPTimer));
+	memset(&xARPResolutionTimer, 0, sizeof(xARPResolutionTimer));
+	memset(&xTCPTimer, 0, sizeof(xTCPTimer));
+
+	// These globals can store sockets for further access by the IP thread,
+	// we need to update otherwise the IP thread may crash again.
+	xSocketToClose  = NULL;
+	xSocketToListen = NULL;
+	memset(&xBoundTCPSocketsList, 0, sizeof(xBoundTCPSocketsList));
+	memset(&xBoundUDPSocketsList, 0, sizeof(xBoundUDPSocketsList));
+	memset(&xDHCPv4Socket, 0, sizeof(xDHCPv4Socket));
+
+	// Other globals which we must reset.
+	xNetworkEventQueue        = NULL;
+	pxARPWaitingNetworkBuffer = NULL;
+	memset(&xSegmentList, 0, sizeof(xSegmentList));
+	xTCPSegments              = NULL;
+	pxNetworkInterfaces       = NULL;
+	pxARPWaitingNetworkBuffer = NULL;
+	memset(&xARPCache, 0, sizeof(xARPCache));
+	memset(&xDNSCache, 0, sizeof(xDNSCache));
+	xNetworkDownEventPending = 0;
+	xDHCPSocketUserCount     = 0;
+
+	/// Reset data from `.data`
+
+	xDNS_IP_Preference = xPreferenceIPv4;
+
+	// Note: do not reset `ucDefaultPartUDPPacketHeader` and
+	// `xDefaultPartARPPacketHeader` because these globals are `const`,
+	// i.e., only accessible through a read-only capability, and thus not
+	// modifiable by a potentially compromised compartment.
+}
+
 void __cheri_compartment("TCPIP") ip_thread_entry(void)
 {
 	FreeRTOS_printf(("ip_thread_entry\n"));
-	while (threadEntryGuard == 0)
+
+	networkThreadID = thread_id_get();
+
+	while (1)
 	{
-		FreeRTOS_printf(("Sleeping until the IP task is supposed to start\n"));
-		futex_wait(&threadEntryGuard, 0);
+		while (threadEntryGuard == 0)
+		{
+			FreeRTOS_printf(
+			  ("Sleeping until the IP task is supposed to start\n"));
+			futex_wait(&threadEntryGuard, 0);
+		}
+
+		// Reset the guard now: we will only ever re-enter this
+		// function in the case of a network stack reset, in which case
+		// we want to wait again for a call to `ip_thread_start`.
+		//
+		// Note that we cannot reset this in `ip_cleanup`, because that
+		// would overwrite the 1 written by `ip_thread_start` if the
+		// latter was called before we call `ip_cleanup`. This will
+		// happen if the IP thread crashes, in which case we would
+		// first call `ip_thread_start` in the error handler, and then
+		// reset the context to `ip_thread_entry` (itself then calling
+		// `ip_cleanup`).
+		threadEntryGuard = 0;
+
+		xIPTaskHandle = networkThreadID;
+		FreeRTOS_printf(
+		  ("ip_thread_entry starting, thread ID is %p\n", xIPTaskHandle));
+
+		flaglock_priority_inheriting_lock(&ipThreadLockState);
+
+		// FreeRTOS event loop. This will only return if a user thread
+		// crashed.
+		prvIPTask(NULL);
+
+		flaglock_unlock(&ipThreadLockState);
 	}
-	xIPTaskHandle = thread_id_get();
-	FreeRTOS_printf(
-	  ("ip_thread_entry starting, thread ID is %p\n", xIPTaskHandle));
-	flaglock_priority_inheriting_lock(&ipThreadLockState);
-	prvIPTask(NULL);
-	FreeRTOS_printf(("ip_thread_entry exiting.  This should not happen\n"));
 }

--- a/lib/tcpip/externs.c
+++ b/lib/tcpip/externs.c
@@ -28,7 +28,3 @@ uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
 	// This is also bad.
 	return rdcycle64();
 }
-
-
-
-

--- a/lib/tcpip/tcpip-internal.h
+++ b/lib/tcpip/tcpip-internal.h
@@ -1,0 +1,145 @@
+// Copyright SCI Semiconductor and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+#include "../firewall/firewall.hh"
+#include <FreeRTOS_IP.h>
+#include <ds/linked_list.h>
+#include <locks.hh>
+
+/**
+ * Internal helpers and data structures for use inside of the TCP/IP
+ * compartment. These should be called or used only from/in the TCP/IP
+ * compartment.
+ */
+
+/**
+ * Flags for the state of restart.
+ */
+enum [[clang::flag_enum]] RestartState{
+  NotRestarting  = 0,
+  Restarting     = 1,
+  IpThreadKicked = 2,
+  DriverKicked   = 4,
+};
+
+static_assert(RestartStateDriverKickedBit == DriverKicked);
+
+using SocketRingLink = ds::linked_list::cell::Pointer;
+
+/**
+ * The sealed wrapper around a FreeRTOS socket.
+ *
+ * These sealed wrappers are part of a doubly linked list which is used by the
+ * compartment reset code to reset locks and other per-socket structures.
+ */
+struct SealedSocket
+{
+	/**
+	 * Socket epoch. This is used to check if the socket correponds
+	 * to the current instance of the network stack.
+	 */
+	uint64_t socketEpoch;
+	/**
+	 * The lock protecting this socket.
+	 */
+	FlagLockPriorityInherited socketLock;
+	/**
+	 * The FreeRTOS socket.  It would be nice if this didn't require a
+	 * separate allocation but FreeRTOS+TCP isn't designed to support that
+	 * use case.
+	 */
+	FreeRTOS_Socket_t *socket;
+	/**
+	 * Link into the sealed sockets doubly-linked list.
+	 */
+	SocketRingLink ring __attribute__((__cheri_no_subobject_bounds__)) = {};
+	/**
+	 * Container-of for the above field. This is used to retrieve the
+	 * corresponding sealed socket from a list element.
+	 */
+	__always_inline static struct SealedSocket *from_ring(SocketRingLink *c)
+	{
+		return reinterpret_cast<struct SealedSocket *>(
+		  reinterpret_cast<uintptr_t>(c) - offsetof(struct SealedSocket, ring));
+	}
+};
+
+/**
+ * Store pointers to the sealed sockets.
+ *
+ * This is used as part of the network stack reset to clean up sockets and
+ * unblock threads waiting on message queues.
+ *
+ * This will be reset by the error handler, however it *is* reset-critical.
+ */
+extern ds::linked_list::Sentinel<SocketRingLink> sealedSockets;
+
+/**
+ * Synchronize accesses to the sealed sockets list above.
+ */
+extern FlagLockPriorityInherited sealedSocketsListLock;
+
+/**
+ * State machine of the restart process. Used for synchronization across the
+ * TCP/IP stack and with the firewall.
+ *
+ * TODO This could be merged together in the upper bits of
+ * `currentSocketEpoch`.
+ */
+extern std::atomic<uint8_t> restartState;
+
+/**
+ * Keep track of the total number of user threads live in the network stack.
+ * This is used to ensure that all threads have been adequately terminated when
+ * performing a network stack reset.
+ *
+ * This should not be reset by the error handler and is reset-critical.
+ */
+extern std::atomic<uint8_t> userThreadCount;
+
+/**
+ * Helper to run a function ensuring that the thread counters are updated
+ * appropriately. Every entry point of the TCP/IP stack API (with the exception
+ * of the driver thread, see below) should go through this unless it
+ * manipulates `userThreadCount` manually.
+ */
+auto with_restarting_checks(auto operation, auto errorValue)
+{
+	if (restartState.load() != 0)
+	{
+		// yield to give a chance to the restart code to make some
+		// progress, in case applications are aggressively trying to
+		// re-open the socket.
+		yield();
+		return errorValue;
+	}
+	userThreadCount++;
+	auto ret = operation();
+	// The decrement will happen in the error handler if the thread
+	// crashes.
+	//
+	// FIXME The decrement will *not* happen when a thread runs out of call
+	// stack in the TCP/IP compartment (because the error handler does not
+	// execute in that case). This will be fixed when we enable the error
+	// handler to run on stack overflow.
+	userThreadCount--;
+	return ret;
+}
+
+/**
+ * Similar to `with_restarting_checks`, but for the driver thread.
+ *
+ * The compartment API entry points exposed to the firewall can only be called
+ * by the firewall, and we trust the firewall not to call us at inappropriate
+ * times during a restart. The firewall has access to `restartState` and knows
+ * when not to call - if it does call at an inapproriate time during reset,
+ * this is a firewall bug. Thus, do not check `restartState` here.
+ */
+auto with_restarting_checks_driver(auto operation, auto errorValue)
+{
+	userThreadCount++;
+	auto ret = operation();
+	userThreadCount--;
+	return ret;
+}

--- a/lib/tcpip/tcpip_error_handler.h
+++ b/lib/tcpip/tcpip_error_handler.h
@@ -1,0 +1,419 @@
+#include "FreeRTOS.h"
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_Sockets.h"
+#include "compartment.h"
+#include "tcpip-internal.h"
+#include <BufferManagement.hh>
+#include <atomic>
+#include <cheri.hh>
+#include <debug.hh>
+#include <locks.hh>
+#include <priv/riscv.h>
+#include <simulator.h>
+#include <vector>
+
+using DebugErrorHandler = ConditionalDebug<true, "TCP/IP Stack error handler">;
+using CHERI::Capability;
+
+/**
+ * Global state to update as part of the reset. These are documented in
+ * `network_wrapper.cc` and `tcpip-internal.h`.
+ */
+extern std::atomic<uint32_t> currentSocketEpoch;
+extern std::atomic<uint8_t>  userThreadCount;
+
+/**
+ * Global lock acquired by the IP thread at startup time. See documentation in
+ * `FreeRTOS_IP_wrapper.c`.
+ */
+extern struct FlagLockState ipThreadLockState;
+
+/**
+ * Other locks and futexes to release as part of the reset. These are
+ * documented in `sdk/include/FreeRTOS-Compat/task.h` in the main tree
+ * (`__CriticalSectionFlagLock` and `__SuspendFlagLock`) and
+ * `source/FreeRTOS_IP.c` in the FreeRTOS+TCP tree (`xNetworkEventQueue`).
+ */
+extern struct RecursiveMutexState __CriticalSectionFlagLock;
+extern struct RecursiveMutexState __SuspendFlagLock;
+extern QueueHandle_t              xNetworkEventQueue;
+
+/**
+ * Restart the network stack. See documentation in `startup.cc`
+ */
+extern void network_restart();
+
+/**
+ * Thread ID of the network thread. See documentation in
+ * `FreeRTOS_IP_wrapper.c`.
+ */
+extern uint16_t networkThreadID;
+
+/**
+ * Free the compartment's heap memory.
+ *
+ * Note that socket memory will not be freed because sockets are allocated with
+ * user-passed capabilities which we do not store. API users are supposed to
+ * close them, which will trigger a free.
+ */
+__always_inline static inline void free_compartment_memory()
+{
+	// Global heap capability.
+	heap_free_all(MALLOC_CAPABILITY);
+	// Buffer manager capability. If the buffer manager is using the global
+	// heap capability, this will do nothing.
+	free_buffer_manager_memory();
+}
+
+/**
+ * Reset the network stack state.
+ *
+ * This is meant to be called by the error handler below. Some of it may be
+ * moved to a normal (non-error-handler context) at a later point - mainly
+ * Phase 3, see comments in the body.
+ *
+ * We go through all locks used in the TCP/IP compartment and set them for
+ * destruction. The list of synchronization primitives resetted here was
+ * extracted through a manual study of the compartment's code-base: this may
+ * therefore break if new releases of FreeRTOS+TCP introduce new locks. In the
+ * future, we may want to come up with a more systematic approach.
+ *
+ * This function is designed to be robust against most types of compartment
+ * corruption, however we do assume that:
+ * - 'reset-critical' data has not been corrupted
+ * - the control-flow of threads in the compartment has not been altered
+ * - spatial and temporal memory safety are not violated
+ */
+extern "C" void reset_network_stack_state()
+{
+	/// Phase 1: Do bookkeeping and determine if we are already in a reset:
+	/// should we do anything at all?
+	const bool IsUserThread = thread_id_get() != networkThreadID;
+	const bool IsIpThread   = !IsUserThread;
+
+	if (IsUserThread)
+	{
+		DebugErrorHandler::log(
+		  "User thread TCP/IP stack error handler called!");
+		userThreadCount--;
+	}
+	else
+	{
+		DebugErrorHandler::log(
+		  "Network thread TCP/IP stack error handler called!");
+	}
+
+	// Manually unlock the sealed sockets lock list if it was held.
+	if (sealedSocketsListLock.get_owner_thread_id() == thread_id_get())
+	{
+		// This situation may happen if we crash in
+		// `network_socket_create_and_bind` because we hold the lock
+		// for more than simply editing the list (to simplify error
+		// handling).
+		//
+		// If that is not the case, and we are here because we crashed
+		// while adding to the list, we may not be able to recover
+		// later because the list is reset-critical.
+		DebugErrorHandler::log("The sealed sockets lock was held by the "
+		                       "crashing thread. Forcefully unlocking it.");
+		sealedSocketsListLock.unlock();
+	}
+
+	// Set the currently restarting flag. This will do several things:
+	// 1. ensure that only one call to this error handler triggers a reset
+	// 2. ensure that no thread enters the compartment while we are
+	//    restarting
+	// 3. reset the network thread whenever it wakes up
+	uint8_t expected = NotRestarting;
+	if (!restartState.compare_exchange_strong(expected, Restarting))
+	{
+		// `expected` now contains a snapshot of `restartState`.
+		if (IsIpThread && ((expected & IpThreadKicked) != 0))
+		{
+			// Currently recovering from a crash that happens
+			// during the reset process is not possible. It is not
+			// clear if we ever really want to do that: we will
+			// only crash during reset if 1) there is a bug in the
+			// reset code, or 2) there is some global data that we
+			// cannot reset and which is corrupted. In either case,
+			// re-reseting the same way will not make the situation
+			// better.
+			DebugErrorHandler::log("The network thread crashed while "
+			                       "restarting. This may be unrecoverable.");
+		}
+
+		// Another instance of the error handler is running, do not do
+		// anything.
+		return;
+	}
+
+	/// Phase 2: Unblock and evacuate all threads from the network stack
+	/// (apart from the network thread).
+	DebugErrorHandler::log("Resetting the network stack.");
+
+	// We need to acquire the sealed sockets lock because we do not want
+	// the sealed sockets list to be in an inconsistent state when we go
+	// over it.
+	//
+	// Waiting to acquire the lock is fine, as we know that any thread
+	// which holds the it will eventually release it, either 1) exiting the
+	// critical section, or 2) crashing into it, in which case we (the
+	// error handler) will manually unlock it (see manual unlock above).
+	//
+	// FIXME: This is not true if the thread runs out of call stack. This
+	// will be fixed when we allow the error handler to run on stack
+	// overflow.
+	//
+	// Note that the internal state of the lock should not be corrupted
+	// unless spatial or temporal memory safety was somehow violated.
+	DebugErrorHandler::log("Acquiring the sealed sockets lock.");
+	sealedSocketsListLock.lock();
+
+	DebugErrorHandler::log(
+	  "Setting the sealed sockets list lock for destruction.");
+	sealedSocketsListLock.upgrade_for_destruction();
+
+	// Upgrade socket locks for destruction and destroy event groups to
+	// ensure that threads waiting on them exit the compartment. We will
+	// empty the list later.
+	//
+	// FIXME This should be made more resilient against corruption of the
+	// linked list by checking all pointers.
+	DebugErrorHandler::log(
+	  "Setting socket locks for destruction and destroying event groups.");
+	if (!sealedSockets.is_empty())
+	{
+		auto *cell = sealedSockets.first();
+		while (cell != &sealedSockets.sentinel)
+		{
+			struct SealedSocket *socket = SealedSocket::from_ring(cell);
+
+			FlagLockPriorityInherited *lock = &(socket->socketLock);
+			if (Capability{lock}.is_valid())
+			{
+				DebugErrorHandler::log("Destroying socket lock {}.", lock);
+				lock->upgrade_for_destruction();
+			}
+			else
+			{
+				DebugErrorHandler::log("Ignoring corrupted socket lock {}.",
+				                       lock);
+			}
+
+			FreeRTOS_Socket_t *s = socket->socket;
+			if (Capability{s}.is_valid() &&
+			    Capability{s->xEventGroup}.is_valid())
+			{
+				DebugErrorHandler::log("Destroying event group {}.",
+				                       s->xEventGroup);
+				eventgroup_destroy_force(MALLOC_CAPABILITY, s->xEventGroup);
+			}
+			else
+			{
+				// The memory of the event group will still be
+				// freed later with the `heap_free_all`,
+				// however we run the risk to have the IP
+				// thread stuck on the event queue which we
+				// didn't manage to destroy.
+				DebugErrorHandler::log("Ignoring corrupted socket {}.", s);
+			}
+
+			cell = cell->cell_next();
+		}
+	}
+
+	DebugErrorHandler::log("Resetting the sealed sockets list.");
+	sealedSockets.reset();
+
+	// Upgrade the two critical section locks for destruction
+	DebugErrorHandler::log("Upgrading critical sections for destruction.");
+	flaglock_upgrade_for_destruction(&__CriticalSectionFlagLock.lock);
+	flaglock_upgrade_for_destruction(&__SuspendFlagLock.lock);
+
+	// Upgrade the message queue lock for destruction
+	DebugErrorHandler::log("Upgrading the message queue for destruction.");
+	auto *queueHandle = &xNetworkEventQueue->handle;
+	if (int err = queue_destroy(MALLOC_CAPABILITY, queueHandle); err != 0)
+	{
+		DebugErrorHandler::log(
+		  "Failed to upgrade the message queue for destruction (error {}).",
+		  err);
+	}
+
+	// Wait for all user threads to exit.
+	DebugErrorHandler::log("Waiting for all threads to exit.");
+	while (userThreadCount.load() != 0)
+	{
+		// Here, we may also want to experiment with
+		// `switcher_interrupt_thread` to get threads to die faster.
+
+		DebugErrorHandler::log("Waiting for {} user thread(s) to terminate.",
+		                       userThreadCount.load());
+
+		// Threads may also be waiting on the allocator in an
+		// out-of-memory situation. Do a `heap_free_all` to unblock
+		// them. We must do this in the loop body in case threads
+		// re-enter OOM multiple times.
+		//
+		// We will do another free at the end of the reset to ensure
+		// that everything is cleaned up in case threads allocate
+		// memory again before terminating.
+		free_compartment_memory();
+
+		Timeout t{1};
+		thread_sleep(&t);
+	}
+
+	// Wait for the IP thread to reset (unless this error handler is
+	// running from the IP thread).
+	if (IsUserThread)
+	{
+		DebugErrorHandler::log("Waiting for the IP thread to reset.");
+		// We will only manage to lock this when the IP thread releases
+		// the lock, which will happen when it re-enters its
+		// initialization phase.
+		flaglock_lock(&ipThreadLockState);
+		// Release the lock as we want the IP thread to grab it again
+		// when we unleash it.
+		flaglock_unlock(&ipThreadLockState);
+	}
+
+	/// Phase 3: Now that only the network thread is present in the
+	/// compartment, reset the network stack into a pristine state. With
+	/// some more work, this may be moved to a non-error-handler context.
+
+	// At this point all user threads have exited the TCP/IP stack
+	// compartment and the network thread context has been reinstalled.
+	DebugErrorHandler::Assert(userThreadCount.load() == 0,
+	                          "All user threads should be terminated by now.");
+
+	// Free heap memory.  We must do this *again*, because threads may have
+	// allocated memory since the previous calls to `heap_free_all`.
+	DebugErrorHandler::log("Freeing heap memory.");
+	free_compartment_memory();
+
+	// Update the socket epoch. We want to do this after all threads have
+	// terminated in case some threads were allocating new sockets during
+	// the restart.
+	currentSocketEpoch++;
+
+	// Re-initialize the locks we updated for destruction earlier.
+	__CriticalSectionFlagLock.lock.lockWord = 0;
+	__CriticalSectionFlagLock.depth         = 0;
+	__SuspendFlagLock.lock.lockWord         = 0;
+	__SuspendFlagLock.depth                 = 0;
+	memset(&sealedSocketsListLock, 0, sizeof(FlagLockPriorityInherited));
+
+	// Restart the network stack. This resets the startup state before
+	// calling `network_start`.
+	DebugErrorHandler::log("Restarting the network stack.");
+	restartState |= IpThreadKicked;
+	network_restart();
+
+	// We do not reset `restartState` here, the network thread will take
+	// care of it when the TCP/IP stack is done reseting.
+}
+
+extern void ip_thread_entry(void);
+
+extern "C" ErrorRecoveryBehaviour
+compartment_error_handler(ErrorState *frame, size_t mcause, size_t mtval)
+{
+	auto threadID = thread_id_get();
+	if (mcause == priv::MCAUSE_CHERI)
+	{
+		auto [exceptionCode, registerNumber] =
+		  CHERI::extract_cheri_mtval(mtval);
+		// The thread entry point is called with a NULL return address so the
+		// cret at the end of the entry point function will trap if it is
+		// reached. We don't want to treat this as an error but thankfully we
+		// detect it quite specifically by checking for all of:
+		// 1) CHERI cause is tag violation
+		// 2) faulting register is CRA
+		// 3) value of CRA is NULL
+		// 4) we've reached the top of the thread's stack
+		Capability stackCapability{
+		  frame->get_register_value<CHERI::RegisterNumber::CSP>()};
+		Capability returnCapability{
+		  frame->get_register_value<CHERI::RegisterNumber::CRA>()};
+		if (registerNumber == CHERI::RegisterNumber::CRA &&
+		    returnCapability.address() == 0 &&
+		    exceptionCode == CHERI::CauseCode::TagViolation &&
+		    stackCapability.top() == stackCapability.address())
+		{
+			// looks like thread exit -- just log it then ForceUnwind
+			DebugErrorHandler::log(
+			  "Thread exit CSP={}, PCC={}", stackCapability, frame->pcc);
+		}
+		else if (exceptionCode == CHERI::CauseCode::None)
+		{
+			// An unwind occurred from a called compartment, just resume.
+			return ErrorRecoveryBehaviour::InstallContext;
+		}
+		else
+		{
+			// An unexpected error -- log it and restart the stack.
+			// Note: handle CZR differently as `get_register_value`
+			// will return a nullptr which we cannot dereference.
+			DebugErrorHandler::log(
+			  "{} error at {} (return address: {}), with capability register "
+			  "{}: {} by thread {}",
+			  exceptionCode,
+			  frame->pcc,
+			  frame->get_register_value<CHERI::RegisterNumber::CRA>(),
+			  registerNumber,
+			  registerNumber == CHERI::RegisterNumber::CZR
+			    ? nullptr
+			    : *frame->get_register_value(registerNumber),
+			  threadID);
+
+			// TODO before running the reset function we should go
+			// to the top of the stack to ensure that we do not run
+			// out of stack space while executing the error
+			// handler.
+
+			// Reset the network stack state.
+			reset_network_stack_state();
+
+			// Now we should either rewind if this is a user
+			// thread, or reinstall the context if this is the
+			// network thread.
+			if (threadID == networkThreadID)
+			{
+				// Reset the stack pointer to the top of the stack.
+				Capability<void *> stack{
+				  frame->get_register_value(CHERI::RegisterNumber::CSP)};
+				DebugErrorHandler::log("Resetting the stack from {} -> {}.",
+				                       stack.address(),
+				                       stack.base());
+				stack.address() = stack.base();
+				DebugErrorHandler::log("Stack length is {}.", stack.length());
+
+				// Reset the program counter.
+				DebugErrorHandler::log(
+				  "Reinstalling context to ip_thread_entry.");
+				frame->pcc = (void *)&ip_thread_entry;
+
+				// We will now run `ip_thread_entry`.
+				return ErrorRecoveryBehaviour::InstallContext;
+			}
+
+			DebugErrorHandler::log("Rewinding crashed user thread {}.",
+			                       threadID);
+			return ErrorRecoveryBehaviour::ForceUnwind;
+		}
+	}
+	else
+	{
+		// other error (e.g. __builtin_trap causes ReservedInstruciton)
+		// log and end simulation with error.
+		DebugErrorHandler::log("Unhandled error {} at {} by thread {}",
+		                       mcause,
+		                       frame->pcc,
+		                       threadID);
+		Capability<void *> stack{
+		  frame->get_register_value(CHERI::RegisterNumber::CSP)};
+		DebugErrorHandler::log("Stack length is {}.", stack.length());
+	}
+	return ErrorRecoveryBehaviour::ForceUnwind;
+}

--- a/lib/tcpip/xmake.lua
+++ b/lib/tcpip/xmake.lua
@@ -39,18 +39,20 @@ compartment("TCPIP")
   add_files("network_wrapper.cc")
   add_files("startup.cc")
   add_files(
-            "../../third_party/freertos-plus-tcp/source/FreeRTOS_ARP.c",
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_BitConfig.c",
-            "../../third_party/freertos-plus-tcp/source/FreeRTOS_DHCP.c",
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_DNS.c",
-            "../../third_party/freertos-plus-tcp/source/FreeRTOS_DNS_Cache.c",
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_DNS_Callback.c",
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_DNS_Networking.c",
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_DNS_Parser.c",
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_ICMP.c",
             -- Included via a wrapper that statically creates the thread.
+            --"../../third_party/freertos-plus-tcp/source/FreeRTOS_DNS_Cache.c",
+            --"../../third_party/freertos-plus-tcp/source/FreeRTOS_ARP.c",
+            --"../../third_party/freertos-plus-tcp/source/FreeRTOS_DHCP.c",
             --"../../third_party/freertos-plus-tcp/source/FreeRTOS_IP.c",
-            "../../third_party/freertos-plus-tcp/source/FreeRTOS_IP_Timers.c",
+            --"../../third_party/freertos-plus-tcp/source/FreeRTOS_TCP_IP.c",
+            --"../../third_party/freertos-plus-tcp/source/FreeRTOS_TCP_WIN.c",
+            --"../../third_party/freertos-plus-tcp/source/FreeRTOS_IP_Timers.c",
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_IP_Utils.c",
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_IPv4.c",
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_IPv4_Sockets.c",
@@ -60,7 +62,6 @@ compartment("TCPIP")
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_Routing.c",
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_Sockets.c",
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_Stream_Buffer.c",
-            "../../third_party/freertos-plus-tcp/source/FreeRTOS_TCP_IP.c",
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_TCP_IP_IPv4.c",
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_TCP_Reception.c",
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_TCP_State_Handling.c",
@@ -69,7 +70,6 @@ compartment("TCPIP")
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_TCP_Transmission_IPv4.c",
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_TCP_Utils.c",
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_TCP_Utils_IPv4.c",
-            "../../third_party/freertos-plus-tcp/source/FreeRTOS_TCP_WIN.c",
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_Tiny_TCP.c",
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_UDP_IP.c",
             "../../third_party/freertos-plus-tcp/source/FreeRTOS_UDP_IPv4.c"


### PR DESCRIPTION
The TCP/IP stack currently has a lot of state and cannot recover gracefully in case of failure. This commit addresses this limitation.

We introduce a custom error handler for the TCP/IP stack. At a high-level, this error handler terminates all user threads currently present in the TCP/IP compartment and resets the IP thread to its entry point `ip_thread_entry`. It does so by setting all the locks of the compartment for destruction and notifying all futex waiters. Then it frees all heap allocations and resets globals. After all the state has been cleaned up, it restarts the network stack.

**At this stage, this is more of a RFC than a proper PR for merge.** Some documentation TODOs are still there, which I will process in the coming days.

This PR was tested as following:

- *Network thread crash*: A crash of the network thread can conveniently be triggered through a ping with the following patch to FreeRTOS+TCP:

```
diff --git a/source/FreeRTOS_ICMP.c b/source/FreeRTOS_ICMP.c
index 78cc9c6..226866f 100644
--- a/source/FreeRTOS_ICMP.c
+++ b/source/FreeRTOS_ICMP.c
@@ -71,6 +71,8 @@
 
 #if ( ipconfigREPLY_TO_INCOMING_PINGS == 1 ) || ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
 
+static int counter = 0;
+
 /**
  * @brief Process an ICMP packet. Only echo requests and echo replies are recognised and handled.
  *
@@ -98,6 +100,16 @@
             /* coverity[misra_c_2012_rule_11_3_violation] */
             ICMPPacket_t * pxICMPPacket = ( ( ICMPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
 
+       if (counter > 0)
+       {
+               printf("(!) triggering a crash\n");
+               *((volatile int *) 0x0) = 0;
+       }
+       else
+       {
+               counter++;
+       }
+
             switch( pxICMPPacket->xICMPHeader.ucTypeOfMessage )
             {
                 case ipICMP_ECHO_REQUEST:
```

   Note that this ignores the first ping received by the system as one ping may be sent by the network in the first boot phase. You may thus need to send two pings to trigger the crash depending on your network setup. Feel free to adjust this.

- *User thread crash*: A tricky user thread crash can be triggered in the critical section of the sealed socket locks with the following patch:

```
diff --git a/lib/tcpip/network_wrapper.cc b/lib/tcpip/network_wrapper.cc
index 00510a6..8201159 100644
--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -483,6 +483,7 @@ int network_host_resolve(const char     *hostname,
 	  -1 /* invalid if we are restarting */);
 }
 
+static int counter = 0;
 SObj network_socket_create_and_bind(Timeout       *timeout,
                                     SObj           mallocCapability,
                                     bool           isIPv6,
@@ -562,6 +563,16 @@ SObj network_socket_create_and_bind(Timeout       *timeout,
 			  localAddress.sin_family = Family;
 			  auto bindResult =
 			    FreeRTOS_bind(socket, &localAddress, sizeof(localAddress));
+			  if (counter == 1)
+			  {
+				  counter++;
+				  printf("(!) triggering a crash in socket create\n");
+				  *((volatile int *)0x0) = 0;
+			  }
+			  else
+			  {
+				  counter++;
+			  }
 			  if (bindResult != 0)
 			  {
 				  // See above comments.
```

   The TCP/IP stack should detect that the crash happened with the lock held, forcefully unlock it, and continue its business.

**Unmerged dependencies in the main RTOS tree.** We need the following two PRs, which will be merged soon:
- https://github.com/microsoft/cheriot-rtos/pull/249
- https://github.com/microsoft/cheriot-rtos/pull/248

**Known issue:**
- The timeout of `malloc` is still not quite right: https://github.com/microsoft/cheriot-rtos/blob/main/sdk/include/stdlib.h#L96

   The value of 30 is generally enough, however in one instance it was still too low and triggered a hang during reset. We should consider increasing this value at a later point or find a more bullet-proof solution. You can easily detect such hangs with the following patch to FreeRTOS+TCP:

```
diff --git a/source/FreeRTOS_TCP_WIN.c b/source/FreeRTOS_TCP_WIN.c
index 8296657..65a02cb 100644
--- a/source/FreeRTOS_TCP_WIN.c
+++ b/source/FreeRTOS_TCP_WIN.c
@@ -430,6 +430,7 @@
 
             if( xTCPSegments == NULL )
             {
+                printf("Allocation of sectors failed.\n");
                 FreeRTOS_debug_printf( ( "prvCreateSectors: malloc %u failed\n",
                                          ( unsigned ) ( ipconfigTCP_WIN_SEG_COUNT * sizeof( xTCPSegments[ 0 ] ) ) ) );
```