### PR TITLE
Make SNTP connection failure (more) reliable.

### DIFF
--- a/examples/01.SNTP/sntp.cc
+++ b/examples/01.SNTP/sntp.cc
@@ -19,6 +19,7 @@ void __cheri_compartment("sntp_example") example()
 	{
 		Debug::log("Failed to update NTP time");
 		Timeout oneSecond{MS_TO_TICKS(1000)};
+		t = Timeout{MS_TO_TICKS(5000)};
 	}
 	Debug::log("Updating NTP took {} ticks", t.elapsed);
 	t = UnlimitedTimeout;

--- a/examples/03.HTTPS/https.cc
+++ b/examples/03.HTTPS/https.cc
@@ -32,6 +32,7 @@ void __cheri_compartment("https_example") example()
 	{
 		Debug::log("Failed to update NTP time");
 		Timeout oneSecond{MS_TO_TICKS(1000)};
+		t = Timeout{MS_TO_TICKS(5000)};
 	}
 	Debug::log("Updating NTP took {} ticks", t.elapsed);
 	t = UnlimitedTimeout;

--- a/examples/04.MQTT/mqtt.cc
+++ b/examples/04.MQTT/mqtt.cc
@@ -96,6 +96,7 @@ void __cheri_compartment("mqtt_example") example()
 	{
 		Debug::log("Failed to update NTP time");
 		Timeout oneSecond{MS_TO_TICKS(1000)};
+		t = Timeout{MS_TO_TICKS(5000)};
 	}
 	Debug::log("Updating NTP took {} ticks", t.elapsed);
 	t = UnlimitedTimeout;


### PR DESCRIPTION
There are two reliability issues in the SNTP code which I happened to discover while I was setting up my machine to do some CHERIoT hacking.

Right now if we fail in the last step of `ntp_time_update` (when we do `Smtp_ReceiveTimeResponse`) because of a network error, we run into an infinite loop of retries. Even worse, the loop does not print anything (the system looks frozen).

Also, although `sntp_update` is run in a loop in the examples, we do not reset the timeout before calling `sntp_update`, which leads subsequent calls to always fail.

Address this by not calling again `Smtp_ReceiveTimeResponse` if we reach the timeout and reset-ing the timeout before calling again `sntp_update` in examples.