### PR TITLE
Fix incorrect assert in `network_socket_close`.

### DIFF
--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -713,7 +713,7 @@ int network_socket_close(Timeout *t, SObj mallocCapability, SObj sealedSocket)
 			  int ret = 0;
 			  if (socket->socketEpoch == currentSocketEpoch.load())
 			  {
-				  Debug::Assert(ds::linked_list::is_singleton(&(socket->ring)),
+				  Debug::Assert(!ds::linked_list::is_singleton(&(socket->ring)),
 				                "The socket should be present in the list.");
 				  if (LockGuard g{sealedSocketsListLock, t})
 				  {


### PR DESCRIPTION
This assert is exactly the wrong way around - the socket ring node will be a singleton iff it is not present in the list.