### PR TITLE
Fix type confusion in the firewall pointer-based `remove`.

### DIFF
--- a/lib/firewall/firewall.cc
+++ b/lib/firewall/firewall.cc
@@ -319,8 +319,9 @@ namespace
 		{
 			memmove(element,
 			        element + 1,
-			        size() - (reinterpret_cast<uint8_t *>(element + 1) -
-			                  reinterpret_cast<uint8_t *>(base())));
+			        size() - ((reinterpret_cast<uint8_t *>(element + 1) -
+			                   reinterpret_cast<uint8_t *>(base())) /
+			                  sizeof(T)));
 			set_size(size() - 1);
 		}
 
@@ -412,6 +413,14 @@ namespace
 			  testSmallTable.size() == 0,
 			  "Small table size is wrong after removal ({}, expected 0}",
 			  testSmallTable.size());
+			Debug::log("Testing small table pointer-based remove");
+			testSmallTable.insert(1);
+			testSmallTable.remove(testSmallTable.begin());
+			Debug::Assert(
+			  testSmallTable.size() == 0,
+			  "Small table size is wrong after removal ({}, expected 0}",
+			  testSmallTable.size());
+
 			Debug::log("Finished small table tests");
 		}
 	}


### PR DESCRIPTION
`size()` returns a size in number of objects, however it is substracted a value in bytes in the pointer-based `remove` function. This results in various flavors of memory corruption.

Fix the function and ensure that it is covered by the tests.