### PR TITLE
tls.cc precisely_bound_buffer representation fix

### DIFF
--- a/lib/tls/tls.cc
+++ b/lib/tls/tls.cc
@@ -217,8 +217,9 @@ namespace
 			static constexpr size_t MantissaBits = 9;
 			// Shrink the length to the largest representable length that we
 			// can fit.
-			length = std::min<size_t>(
-			  length, ((1 << MantissaBits) - 1) << __builtin_ctz(baseAddress));
+			length = std::min<size_t>(length & alignmentMask,
+			                          ((1 << MantissaBits) - 1)
+			                            << __builtin_ctz(baseAddress));
 			Debug::log("Reducing length to {}", length);
 			Debug::Assert(
 			  [=]() {


### PR DESCRIPTION
@rmn30 points out that just because the requested length is shorter than the maximum representable length doesn't mean that it's representable. Round the requested length down by the alignment mask first!