### PR TITLE
Move to a stack-overflow-resilient error handler

### DIFF
--- a/lib/tcpip/FreeRTOS_IP_wrapper.c
+++ b/lib/tcpip/FreeRTOS_IP_wrapper.c
@@ -17,6 +17,7 @@ void ip_thread_start(void);
 #include <futex.h>
 #include <locks.h>
 #include <stdatomic.h>
+#include <unwind.h>
 
 /**
  * Flag used to synchronize the network stack thread and user threads at
@@ -106,6 +107,8 @@ void ip_cleanup(void)
 	// modifiable by a potentially compromised compartment.
 }
 
+extern void reset_network_stack_state(bool isIpThread);
+
 void __cheri_compartment("TCPIP") ip_thread_entry(void)
 {
 	FreeRTOS_printf(("ip_thread_entry\n"));
@@ -114,36 +117,47 @@ void __cheri_compartment("TCPIP") ip_thread_entry(void)
 
 	while (1)
 	{
-		while (threadEntryGuard == 0)
+		CHERIOT_DURING
 		{
+			while (threadEntryGuard == 0)
+			{
+				FreeRTOS_printf(
+				  ("Sleeping until the IP task is supposed to start\n"));
+				futex_wait(&threadEntryGuard, 0);
+			}
+
+			// Reset the guard now: we will only ever re-iterate
+			// the loop in the case of a network stack reset, in
+			// which case we want to wait again for a call to
+			// `ip_thread_start`.
+			//
+			// Note that we cannot reset this in `ip_cleanup`,
+			// because that would overwrite the 1 written by
+			// `ip_thread_start` if the latter was called before we
+			// call `ip_cleanup`. This will happen if the IP thread
+			// crashes, in which case we would first call
+			// `ip_thread_start` in the error handler, and then
+			// reset the context to `ip_thread_entry` (itself then
+			// calling `ip_cleanup`).
+			threadEntryGuard = 0;
+
+			xIPTaskHandle = networkThreadID;
 			FreeRTOS_printf(
-			  ("Sleeping until the IP task is supposed to start\n"));
-			futex_wait(&threadEntryGuard, 0);
+			  ("ip_thread_entry starting, thread ID is %p\n", xIPTaskHandle));
+
+			flaglock_priority_inheriting_lock(&ipThreadLockState);
+
+			// FreeRTOS event loop. This will only return if a user
+			// thread crashed.
+			prvIPTask(NULL);
+
+			flaglock_unlock(&ipThreadLockState);
 		}
-
-		// Reset the guard now: we will only ever re-enter this
-		// function in the case of a network stack reset, in which case
-		// we want to wait again for a call to `ip_thread_start`.
-		//
-		// Note that we cannot reset this in `ip_cleanup`, because that
-		// would overwrite the 1 written by `ip_thread_start` if the
-		// latter was called before we call `ip_cleanup`. This will
-		// happen if the IP thread crashes, in which case we would
-		// first call `ip_thread_start` in the error handler, and then
-		// reset the context to `ip_thread_entry` (itself then calling
-		// `ip_cleanup`).
-		threadEntryGuard = 0;
-
-		xIPTaskHandle = networkThreadID;
-		FreeRTOS_printf(
-		  ("ip_thread_entry starting, thread ID is %p\n", xIPTaskHandle));
-
-		flaglock_priority_inheriting_lock(&ipThreadLockState);
-
-		// FreeRTOS event loop. This will only return if a user thread
-		// crashed.
-		prvIPTask(NULL);
-
-		flaglock_unlock(&ipThreadLockState);
+		CHERIOT_HANDLER
+		{
+			// Call the network stack error handler for the network thread.
+			reset_network_stack_state(true /* this is the IP thread */);
+		}
+		CHERIOT_END_HANDLER
 	}
 }

--- a/lib/tcpip/xmake.lua
+++ b/lib/tcpip/xmake.lua
@@ -5,7 +5,7 @@ option("network-inject-faults")
 
 compartment("TCPIP")
   set_default(false)
-  add_deps("freestanding", "string", "message_queue_library", "event_group", "cxxrt")
+  add_deps("freestanding", "string", "message_queue_library", "event_group", "cxxrt", "unwind_error_handler")
   add_cflags("-Wno-error=int-conversion", "-Wno-error=cheri-provenance", "-Wno-error=pointer-integer-compare", { force = true})
   add_defines("CHERIOT_CUSTOM_DEFAULT_MALLOC_CAPABILITY")
   add_defines("CHERIOT_EXPOSE_FREERTOS_SEMAPHORE")


### PR DESCRIPTION
The TCP/IP stack cannot currently recover from a crash due to a stack overflow in the TCP/IP compartment.  This is due to a limitation of the implementation of the switcher, which cannot trigger the error handler on stack overflow. Further, the current implementation of the error handler runs at the point in the stack where the compartment crashed. This implies that the error handler runs on a potentially very small stack, making it possible that it will itself crash due to a stack overflow. This limitation is documented in https://github.com/CHERIoT-Platform/network-stack/issues/31.

This commit addresses these limitations using David's recently-merged stackless error handler mechanism: https://github.com/CHERIoT-Platform/cheriot-rtos/pull/301.

We also address a bug in the reset, which happens when an error handler on a user thread triggers a crash of the IP thread. In this case, previously improperly tested, we fail to release a lock, resulting in a failure of the reset.

More information in each commit.