### PR TITLE
Firewall: Send a read-only/non-capturable buffer to the TCP/IP stack.

### DIFF
--- a/lib/firewall/firewall.cc
+++ b/lib/firewall/firewall.cc
@@ -1082,7 +1082,11 @@ void __cheri_compartment("Firewall") ethernet_run_driver()
 			auto &frame = *maybeFrame;
 			if (packet_filter_ingress(frame.buffer, frame.length))
 			{
-				ethernet_receive_frame(frame.buffer, frame.length);
+				// Send the frame buffer to the TCP/IP stack as
+				// a read-only, non-capturable capability.
+				CHERI::Capability frameBuffer{frame.buffer};
+				frameBuffer.permissions() &= CHERI::Permission::Load;
+				ethernet_receive_frame(frameBuffer, frame.length);
 			}
 		}
 		receivedCounter += packets;


### PR DESCRIPTION
The firewall currently sends a writable and capturable frame buffer capability to the TCP/IP stack. This is bad because the TCP/IP stack can keep the capability and alter the buffer at a later point when we re-use it. Not sure what the exact impact is, but it sounds like the TCP/IP may be able to use this to add endpoints to the firewall table.