### PR TITLE
Add MQTT support for publishing retained messages

### DIFF
--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -137,6 +137,14 @@ int __cheri_compartment("MQTT")
  *
  * `qos` indicates the level of QoS (0, 1, or 2).
  *
+ * `retain` indicates whether the message should be published as retained or
+ * not. The broker stores the last retained message and the corresponding QoS
+ * for that topic. Each client that subscribes to a topic pattern that matches
+ * the topic of the retained message receives the retained message immediately
+ * after they subscribe. The broker stores only one retained message per topic.
+ * Retained messages are cleared by publishing a zero length message with the
+ * retain flag set.
+ *
  * Both the topic and payload buffers must remain valid during the execution of
  * this function. If the caller frees them during the execution of this
  * function, the publish may leak application data to the broker through the
@@ -181,14 +189,6 @@ int __cheri_compartment("MQTT") mqtt_publish(Timeout    *t,
  * include the zero terminator and must be at least one-character long).
  *
  * `qos` indicates the level of QoS (0, 1, or 2).
- *
- * `retain` indicates whether the message should be published as retained or
- * not. The broker stores the last retained message and the corresponding QoS
- * for that topic. Each client that subscribes to a topic pattern that matches
- * the topic of the retained message receives the retained message immediately
- * after they subscribe. The broker stores only one retained message per topic.
- * Retained messages are cleared by publishing a zero length message with the
- * retain flag set.
  *
  * The filter buffer must remain valid during the execution of this function.
  * If the caller frees it during the execution of this function, the subscribe

--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -170,7 +170,8 @@ int __cheri_compartment("MQTT") mqtt_publish(Timeout    *t,
                                              const char *topic,
                                              size_t      topicLength,
                                              const void *payload,
-                                             size_t      payloadLength);
+                                             size_t      payloadLength,
+                                             bool        retain = false);
 
 /**
  * Subscribe on a given MQTT connection.

--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -181,7 +181,7 @@ int __cheri_compartment("MQTT") mqtt_publish(Timeout    *t,
  * include the zero terminator and must be at least one-character long).
  *
  * `qos` indicates the level of QoS (0, 1, or 2).
- * 
+ *
  * `retain` indicates whether the message should be published as retained or
  * not. The broker stores the last retained message and the corresponding QoS
  * for that topic. Each client that subscribes to a topic pattern that matches

--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -181,6 +181,14 @@ int __cheri_compartment("MQTT") mqtt_publish(Timeout    *t,
  * include the zero terminator and must be at least one-character long).
  *
  * `qos` indicates the level of QoS (0, 1, or 2).
+ * 
+ * `retain` indicates whether the message should be published as retained or
+ * not. The broker stores the last retained message and the corresponding QoS
+ * for that topic. Each client that subscribes to a topic pattern that matches
+ * the topic of the retained message receives the retained message immediately
+ * after they subscribe. The broker stores only one retained message per topic.
+ * Retained messages are cleared by publishing a zero length message with the
+ * retain flag set.
  *
  * The filter buffer must remain valid during the execution of this function.
  * If the caller frees it during the execution of this function, the subscribe


### PR DESCRIPTION
Adds the option to make a published message retained by the broker.

Also sets the bounds on the topic and message passed to the publishCallback so that callback can't access any other parts of the buffer. 