### PR TITLE
sntp: restore storing cycle count to shared block

### DIFF
--- a/lib/sntp/sntp.cc
+++ b/lib/sntp/sntp.cc
@@ -241,6 +241,7 @@ namespace
 		  "Current time: {}.{}", currentTime.seconds, currentTime.fractions);
 		currentUNIXTime.updatingEpoch++;
 		ntp_date_to_timeval(currentUNIXTime, currentTime, ntpEra);
+		currentUNIXTime.cycles = cycles;
 		currentUNIXTime.updatingEpoch++;
 		Debug::log("Updated UNIX time");
 		Debug::log("Current UNIX time: {}.{}",


### PR DESCRIPTION
1f786515bacc1a1ae3f719a4fab531fae30c10e7 erroneously removed the update of the cycle time stamp of the last cached NTP time.