### PR TITLE
TLS recv might send and other fixes

### DIFF
--- a/lib/mqtt/mqtt.cc
+++ b/lib/mqtt/mqtt.cc
@@ -710,7 +710,7 @@ MQTTConnection mqtt_connect(Timeout                    *t,
 	do
 	{
 		// `remaining` is in milliseconds
-		uint32_t remaining = (t->remaining * MS_PER_TICK) / 1000;
+		uint32_t remaining = (t->remaining * MS_PER_TICK);
 		ret                = with_elapse_timeout(t, [&]() {
             return MQTT_Connect(&context->coreMQTTContext,
                                 &connectInfo,

--- a/lib/netapi/NetAPI.cc
+++ b/lib/netapi/NetAPI.cc
@@ -9,7 +9,15 @@
 #include <endianness.hh>
 #include <token.h>
 
-using Debug = ConditionalDebug<false, "Network API">;
+constexpr bool DebugNetAPI =
+#ifdef DEBUG_NETAPI
+  DEBUG_NETAPI
+#else
+  false
+#endif
+  ;
+
+using Debug = ConditionalDebug<DebugNetAPI, "Network API">;
 
 #include "../dns/dns.hh"
 #include "../firewall/firewall.hh"

--- a/lib/netapi/xmake.lua
+++ b/lib/netapi/xmake.lua
@@ -1,4 +1,7 @@
+debugOption("NetAPI")
+
 compartment("NetAPI")
+  add_rules("cheriot.component-debug")
   set_default(false)
   add_includedirs("../../include")
   add_deps("freestanding", "TCPIP")

--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -19,7 +19,15 @@
 #include <platform-ethernet.hh>
 #include <token.h>
 
-using Debug = ConditionalDebug<false, "Network stack wrapper">;
+constexpr bool DebugTCPIP =
+#ifdef DEBUG_TCPIP
+  DEBUG_TCPIP
+#else
+  false
+#endif
+  ;
+
+using Debug = ConditionalDebug<DebugTCPIP, "Network stack wrapper">;
 
 #include "../firewall/firewall.hh"
 

--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -749,7 +749,11 @@ int network_socket_connect_tcp_internal(Timeout       *timeout,
 			  server.sin_address.ulIP_IPv4 = address.ipv4;
 		  }
 		  Debug::log("Trying to connect to server");
-		  switch (FreeRTOS_connect(socket->socket, &server, sizeof(server)))
+		  switch (with_freertos_timeout(
+		    timeout, socket->socket, FREERTOS_SO_RCVTIMEO, [&] {
+			    return FreeRTOS_connect(
+			      socket->socket, &server, sizeof(server));
+		    }))
 		  {
 			  default:
 				  return -EINVAL;

--- a/lib/tcpip/xmake.lua
+++ b/lib/tcpip/xmake.lua
@@ -1,9 +1,12 @@
+debugOption("TCPIP")
+
 option("network-inject-faults")
   set_default(false)
   set_showmenu(true)
   set_description("Inject network faults for testing")
 
 compartment("TCPIP")
+  add_rules("cheriot.component-debug")
   set_default(false)
   add_deps("freestanding", "string", "message_queue_library", "event_group", "cxxrt", "unwind_error_handler", "DNS")
   add_cflags("-Wno-error=int-conversion", "-Wno-error=cheri-provenance", "-Wno-error=pointer-integer-compare", { force = true})

--- a/lib/tls/tls.cc
+++ b/lib/tls/tls.cc
@@ -12,7 +12,15 @@
 #include <tls.h>
 #include <token.h>
 
-using Debug = ConditionalDebug<false, "TLS">;
+constexpr bool DebugTLS =
+#ifdef DEBUG_TLS
+  DEBUG_TLS
+#else
+  false
+#endif
+  ;
+
+using Debug = ConditionalDebug<DebugTLS, "TLS">;
 using namespace CHERI;
 
 /**

--- a/lib/tls/tls.cc
+++ b/lib/tls/tls.cc
@@ -295,6 +295,23 @@ namespace
 				  {
 					  return -ENOTCONN;
 				  }
+
+				  if ((state & BR_SSL_SENDREC) == BR_SSL_SENDREC)
+				  {
+					  // If we need to send records, send them first.
+					  auto [sent, unfinished] = send_records(t, connection);
+					  if (sent == -ECOMPARTMENTFAIL)
+					  {
+						  // The TCP/IP stack crashed; tell the
+						  // caller that the link is dead.
+						  return -ENOTCONN;
+					  }
+					  if (sent <= 0)
+					  {
+						  return sent;
+					  }
+				  }
+
 				  if ((state & BR_SSL_RECVAPP) == BR_SSL_RECVAPP)
 				  {
 					  // If there are data ready to receive, return

--- a/lib/tls/xmake.lua
+++ b/lib/tls/xmake.lua
@@ -1,3 +1,5 @@
+debugOption("TLS")
+
 option("tls-rsa")
     set_default(true)
     set_description("Enable RSA (in addition to ECDSA) for TLS")
@@ -12,6 +14,7 @@ option("tls-sha384")
 
 
 compartment("TLS")
+  add_rules("cheriot.component-debug")
   add_options("tls-rsa", "tls-sha384")
   set_default(false)
   -- TLS API


### PR DESCRIPTION
This isn't a complete fix to the shenanigans going on in here (in particular, we really should be elapsing time even if the current SSL engine state is `0` and we don't take _any_ of these branches in the loop), but it's a step in the right direction and good enough for demo work.