### PR TITLE
DNS: fix error in checking query ID

### DIFF
--- a/lib/dns/dns.cc
+++ b/lib/dns/dns.cc
@@ -621,7 +621,7 @@ namespace
 
 		// Only process DNS messages that correspond to
 		// the query we sent.
-		if (dnsHeader->id == ntohs(queryID))
+		if (dnsHeader->id != queryID)
 		{
 			Debug::log("Ignoring DNS answer for the wrong query.");
 			return;


### PR DESCRIPTION
This check of DNS query ID was totally wrong as it:

1) was checking for equality instead of inequality 
2) was unnecessarily byte swapping the queryID

These two errors combined so that responses were accepted providing the byte swapped queryID did not match the expected queryID.  This meant most responses were accepted unless the query ID had two equal bytes, which occassionally happened by chance and caused the query to time out until the next query chose a different queryID.