### PR TITLE
NetAPI.h: Fix broken DECLARE_AND_DEFINE_CAPABILITY macros.

### DIFF
--- a/examples/04.MQTT/mqtt.cc
+++ b/examples/04.MQTT/mqtt.cc
@@ -40,6 +40,14 @@ DECLARE_AND_DEFINE_CONNECTION_CAPABILITY(MosquittoOrgMQTT,
                                          "test.mosquitto.org",
                                          8883,
                                          ConnectionTypeTCP);
+// Another connection capability for port 1883 (unencrypted)
+// We don't actually use this but it is here as a regression test for
+// https://github.com/CHERIoT-Platform/network-stack/pull/83 as it would fail
+// to compile without that fix.
+DECLARE_AND_DEFINE_CONNECTION_CAPABILITY(MosquittoOrgMQTT2,
+                                         "test.mosquitto.org",
+                                         1883,
+                                         ConnectionTypeTCP);
 
 DECLARE_AND_DEFINE_ALLOCATOR_CAPABILITY(mqttTestMalloc, 32 * 1024);
 

--- a/include/NetAPI.h
+++ b/include/NetAPI.h
@@ -130,7 +130,7 @@ typedef CHERI_SEALED(struct SealedSocket *) Socket;
  */
 #define DECLARE_AND_DEFINE_CONNECTION_CAPABILITY(                              \
   name, authorisedHost, portNumber, connectionType)                            \
-	struct ConnectionCapabilityState##__COUNTER__                              \
+	struct ConnectionCapabilityState##name                                     \
 	{                                                                          \
 		ConnectionType type;                                                   \
 		uint16_t       port;                                                   \
@@ -138,7 +138,7 @@ typedef CHERI_SEALED(struct SealedSocket *) Socket;
 		const char     hostname[sizeof(authorisedHost)];                       \
 	};                                                                         \
 	DECLARE_AND_DEFINE_STATIC_SEALED_VALUE_EXPLICIT_TYPE(                      \
-	  struct ConnectionCapabilityState##__COUNTER__,                           \
+	  struct ConnectionCapabilityState##name,                                  \
 	  ConnectionCapabilityState,                                               \
 	  NetAPI,                                                                  \
 	  NetworkConnectionKey,                                                    \
@@ -166,14 +166,14 @@ typedef CHERI_SEALED(struct SealedSocket *) Socket;
  */
 #define DECLARE_AND_DEFINE_BIND_CAPABILITY(                                    \
   name, isIPv6Binding, portNumber, maxConnections)                             \
-	struct BindCapabilityState##__COUNTER__                                    \
+	struct BindCapabilityState##name                                           \
 	{                                                                          \
 		bool     isIPv6;                                                       \
 		uint16_t port;                                                         \
 		uint16_t maximumNumberOfConcurrentTCPConnections;                      \
 	};                                                                         \
 	DECLARE_AND_DEFINE_STATIC_SEALED_VALUE_EXPLICIT_TYPE(                      \
-	  struct BindCapabilityState##__COUNTER__,                                 \
+	  struct BindCapabilityState##name,                                        \
 	  BindCapabilityState,                                                     \
 	  NetAPI,                                                                  \
 	  NetworkBindKey,                                                          \


### PR DESCRIPTION
These macros were not behaving as intended because the token pasting operator (`##`) was causing `__COUNTER__` not to be expanded. Even if it was it wouldn't work because the two uses of `__COUNTER__` would have different values. The result is that all capabilities have the same name for the type which causes a redefinition error if you try to define two capabilities in the same file.

Fortunately these macros take a name parameter which must already be unique so we can use this to create a type name.