### PR TITLE
Add missing LoadGlobal argument for SHARED_OBJECT_WITH_DATA_PERMISSIONS in SNTP library

### DIFF
--- a/lib/sntp/sntp.cc
+++ b/lib/sntp/sntp.cc
@@ -240,7 +240,7 @@ namespace
 	void unix_time_update(uint64_t cycles)
 	{
 		auto &currentUNIXTime = *SHARED_OBJECT_WITH_PERMISSIONS(
-		  SynchronisedTime, sntp_time_at_last_sync, true, true, false, false);
+		  SynchronisedTime, sntp_time_at_last_sync, true, true, false, false, false);
 		Debug::log("Updating UNIX time");
 		Debug::log(
 		  "Current time: {}.{}", currentTime.seconds, currentTime.fractions);

--- a/lib/sntp/time-helpers.cc
+++ b/lib/sntp/time-helpers.cc
@@ -13,7 +13,7 @@ using Debug = ConditionalDebug<false, "Time helper">;
 int timeval_calculate(struct timeval *__restrict tp)
 {
 	struct SynchronisedTime *sntpTime = SHARED_OBJECT_WITH_PERMISSIONS(
-	  SynchronisedTime, sntp_time_at_last_sync, true, false, false, false);
+	  SynchronisedTime, sntp_time_at_last_sync, true, false, false, false, false);
 	struct timeval time;
 	uint64_t       cycles;
 	uint32_t       epoch;


### PR DESCRIPTION
Pull request [#685](https://github.com/CHERIoT-Platform/cheriot-rtos/pull/685) that was merged several weeks ago to `cheriot-rtos` repository adds LoadGlobal permission configuration for shared objects by modifying `SHARED_OBJECT_WITH_PERMISSIONS` macro definition:

https://github.com/CHERIoT-Platform/cheriot-rtos/pull/685/changes#diff-1107dc935c8ddf927ba75a83affd08ea4a5fa4856e27845939258b492f096694L145-R176

However, SNTP library calls modified macro but without LoadGlobal argument, therefore causing to fail in building examples. This PR adds the fix by setting the LoadGlobal permission to false for both `sntpTime` and `currentUNIXTime` (don't see the need for either of them to have such access).

Tagging @nwf (since he's an author of original PR) and @davidchisnall 