### PR TITLE
Add HIL CI workflow for testing network-stack examples on SONATA

### DIFF
--- a/.github/sonata-hil/README.md
+++ b/.github/sonata-hil/README.md
@@ -1,0 +1,39 @@
+# Sonata Hardware-in-Loop Testing
+
+This directory contains parts of the testing framework used to do HIL testing of the CHERIoT network-stack on sonata hardware.
+
+The board is hosted in The Capable Hub's board farm and details on how it is connected can be found in their [board farm documentation](https://www.thecapablehub.org/docs/hardware/#newae-sonata-one).
+
+The CI workflow handles flashing each of the network-stack example projects onto the board, resets and then monitors the UART for an expected string to indicate success.
+Most of this automation is handled by:
+
+- [pytest](https://docs.pytest.org/en/stable/) - Overall running of each test
+- [Labgrid](https://labgrid.readthedocs.io/en/latest/) - Mainly for monitoring serial and test timeouts
+- usbrelay - Custom software for controlling the state of the RESET (SW5) button
+
+### Files
+
+| File | Description |
+|------|-------------|
+| `run-hil-tests.sh` | Loops through each example, copies the firmware onto the sonata, invokes pytest, dumps the serial log, and cleans up. Tracks pass/fail per test and exits non-zero if any test fails. |
+| `test_generic.py` | The actual pytest test. Releases the board reset via usbrelay, then uses labgrid's `console.expect()` to wait for `EXPECTED_STRING` within `TEST_TIMEOUT` seconds. |
+| `conftest.py` | pytest session config. Activates Labgrid's serial console component so it can begin monitoring before the Reset is released. |
+| `local.yaml` | Labgrid environment file. Describes the hardware target ie serial port `/dev/ttyUSB2` at 921600 baud. |
+
+### Test Flow
+
+The general flow for each test is to setup the hardware and monitor the serial console for some known / expected string (`EXPECTED_STRING`) within the given timeout (`TEST_TIMEOUT`).
+
+```mermaid
+flowchart TD
+    S0[Flash firmware.uf2 to SONATA]
+    S0 --> S1[Force board into reset via usbrelay]
+    S1 --> S2[labgrid opens serial console and starts monitoring]
+    S2 --> S3[Release reset via usbrelay board boots]
+    S3 --> S4{EXPECTED_STRING found before TEST_TIMEOUT?}
+    S4 -->|yes| S5([pass])
+    S4 -->|no | S6([fail])
+    S5 --> S7[Dump serial log]
+    S6 --> S7
+    S7 --> S8[Cleanup + restart dnsmasq]
+```

--- a/.github/sonata-hil/conftest.py
+++ b/.github/sonata-hil/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.fixture(scope="session")
+def console(target):
+    serial = target.get_driver("ConsoleProtocol")
+    target.activate(serial)
+    return serial

--- a/.github/sonata-hil/local.yaml
+++ b/.github/sonata-hil/local.yaml
@@ -1,0 +1,8 @@
+targets:
+  main:
+    resources:
+      RawSerialPort:
+        port: "/dev/ttyUSB2"
+        speed: 921600
+    drivers:
+      SerialDriver: {}

--- a/.github/sonata-hil/run-hil-tests.sh
+++ b/.github/sonata-hil/run-hil-tests.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/labgrid-env/bin/activate
+
+declare -A EXPECTED_STRINGS
+EXPECTED_STRINGS["01.SNTP"]="Current UNIX epoch time:"
+EXPECTED_STRINGS["02.HTTP"]='<a href="https://iana.org/domains/example">Learn more</a>'
+EXPECTED_STRINGS["03.HTTPS"]="No content length header found"
+EXPECTED_STRINGS["04.MQTT"]="Done testing MQTT."
+EXPECTED_STRINGS["05.HTTP_SERVER"]="Listening on port"
+
+TESTS=("01.SNTP" "02.HTTP" "03.HTTPS" "04.MQTT" "05.HTTP_SERVER")
+
+declare -A RESULTS
+overall_result=0
+
+for TEST in "${TESTS[@]}"; do
+  EXPECTED="${EXPECTED_STRINGS[$TEST]}"
+  echo "--- Flashing $TEST firmware ---"
+  cp $(find firmware/$TEST -name "firmware.uf2") "$MOUNT_POINT/"
+  sync
+  sleep 5
+  echo "--- Resetting board ---"
+  sudo usbrelay HURTM_1=1
+  echo "--- Running $TEST test (timeout: 60s, expecting: '$EXPECTED') ---"
+  set +e
+  EXPECTED_STRING="$EXPECTED" TEST_TIMEOUT=60 sudo -E `which pytest` --lg-env .github/sonata-hil/local.yaml --no-header -q --tb=no --lg-log /tmp/labgrid-log .github/sonata-hil/test_generic.py
+  RESULT=$?
+  set -e
+  echo "--- $TEST test result: $( [ $RESULT -eq 0 ] && echo PASSED || echo FAILED ) ---"
+  echo "--- Serial output ---"
+  sudo find /tmp/labgrid-log -type f -exec cat {} \; || true
+  sudo rm -rf /tmp/labgrid-log
+  echo "--- Cleaning up ---"
+  rm -f "$MOUNT_POINT"/*.uf2
+  # Board MAC can change for different tests so wipe the dhcp lease table after each test
+  sudo systemctl stop dnsmasq
+  sudo rm -f /var/lib/misc/dnsmasq.leases
+  sudo systemctl start dnsmasq
+  RESULTS[$TEST]=$( [ $RESULT -eq 0 ] && echo "passed" || echo "failed" )
+  [ $RESULT -ne 0 ] && overall_result=1
+done
+
+echo "--- Test summary ---"
+for TEST in "${TESTS[@]}"; do
+  echo "  $TEST: ${RESULTS[$TEST]}"
+done
+
+if [[ $overall_result -ne 0 ]]; then
+  echo "One or more hardware tests failed."
+  exit 1
+else
+  echo "All hardware tests passed."
+fi

--- a/.github/sonata-hil/test_generic.py
+++ b/.github/sonata-hil/test_generic.py
@@ -1,0 +1,7 @@
+import os
+import subprocess
+
+
+def test_generic(console):
+    subprocess.run(["sudo", "usbrelay", "HURTM_1=0"], check=True)
+    console.expect(os.environ["EXPECTED_STRING"], timeout=int(os.environ.get("TEST_TIMEOUT", 60)))

--- a/.github/workflows/sonata-hil-ci.yml
+++ b/.github/workflows/sonata-hil-ci.yml
@@ -1,0 +1,78 @@
+name: CHERIoT Network-Stack HIL-CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      devcontainer:
+        description: 'Set to override default build container'
+        type: string
+        required: false
+
+jobs:
+  build-examples:
+    name: Build Example Projects
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.devcontainer || 'ghcr.io/cheriot-platform/devcontainer:latest' }}
+      options: --user 1001
+    steps:
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+
+    - name: Check out RTOS
+      run: |
+        cd ..
+        git clone --recurse https://github.com/cheriot-platform/cheriot-rtos
+
+    - name: Build examples for Sonata
+      run: |
+        for d in examples/*/; do (
+          cd $d
+          xmake f --sdk=/cheriot-tools/ --board=sonata-1.3 -m release --IPv6=false
+          xmake run
+        ); done
+
+    - name: Upload firmware artifacts
+      uses: actions/upload-artifact@v7
+      with:
+        name: sonata-firmware
+        path: examples/*/build/**/firmware.uf2
+        if-no-files-found: error
+
+  hardware-test:
+    name: Hardware Test on Sonata
+    needs: build-examples
+    runs-on: [ the-capable-hub-farm, board:Sonata ]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Download firmware artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: sonata-firmware
+        path: firmware
+
+    - name: Mount Sonata
+      run: |
+        # Mount the SONATA at a known location
+        sudo mkdir -p /mnt/SONATA
+        sudo mount -o uid=$(id -u),gid=$(id -g),rw -L SONATA /mnt/SONATA
+
+        # Store mount point for all subsequent steps
+        echo "MOUNT_POINT=/mnt/SONATA" >> $GITHUB_ENV
+
+    - name: Make sure the board is not in reset
+      run: sudo usbrelay HURTM_1=0
+
+    - name: Clean existing firmware
+      run: rm -f "$MOUNT_POINT"/*.uf2
+
+    - name: Flash and test all examples
+      run: bash .github/sonata-hil/run-hil-tests.sh


### PR DESCRIPTION
Uses The Capable Hub's board farm to run the network-stack examples on a SONATA board.

Building and flashing are split into separate jobs to minimise occupation time in the board farm.

A couple of tweaks vs the documented build/run process:
- IPv6 is disabled for the tests as there are known issues.
- The ephemeral VM in the board farm has a limited DHCP range for the target, and the board's MAC changes between tests. The table is cleared between runs to ensure a clean slate.