### PR TITLE
Use user permissions on socket handles

### DIFF
--- a/examples/06.COMPARTMENTALIZED_HTTP_SERVER/README.md
+++ b/examples/06.COMPARTMENTALIZED_HTTP_SERVER/README.md
@@ -1,0 +1,8 @@
+Compartmentalized HTTP Server Example
+=====================================
+
+The [HTTP server example](../05.HTTP_SERVER) uses a single compartment.
+There are many reasons why one would want to break it down into more compartments: for example, one may want to isolate the part processing incoming requests from the part serving content to make it harder to mount a website defacement attack.
+This server is architected in three compartments to show how the network stack's APIs facilitate the design of compartmentalized server software.
+
+Similarly to the previous HTTP server example, note that this is *not* intended as an example of how to build an HTTP server.

--- a/examples/06.COMPARTMENTALIZED_HTTP_SERVER/http_server.cc
+++ b/examples/06.COMPARTMENTALIZED_HTTP_SERVER/http_server.cc
@@ -1,0 +1,251 @@
+#include "http_server.h"
+#include "timeout.h"
+#include <NetAPI.h>
+#if __has_include(<allocator.h>)
+#	include <allocator.h>
+#endif
+#include <debug.hh>
+#include <fail-simulator-on-error.h>
+#include <thread.h>
+#include <tick_macros.h>
+
+using CHERI::Capability;
+
+using Debug            = ConditionalDebug<true, "HTTP server example test">;
+constexpr bool UseIPv6 = CHERIOT_RTOS_OPTION_IPv6;
+
+/**
+ * Bind capability for the server port 80. Use IPv6 if enabled in the
+ * configuration, and allow at most two simultaneous connections to the server.
+ */
+#define LISTEN_PORT 80
+DECLARE_AND_DEFINE_BIND_CAPABILITY(HTTPPort, UseIPv6, LISTEN_PORT, 10);
+
+DECLARE_AND_DEFINE_ALLOCATOR_CAPABILITY(TestMalloc, 32 * 1024);
+#define TEST_MALLOC STATIC_SEALED_VALUE(TestMalloc)
+
+/**
+ * Maximum number of clients the server will server before shutting down. This
+ * is useful to check that the server can handle multiple clients before
+ * terminating.
+ */
+static const uint16_t MaxClients = 10;
+
+/**
+ * This example server is written to showcase the network stack server API, but
+ * also the network stack restart. If one of the network stack APIs fails in a
+ * way likely caused by a crash, the server will wait this small delay before
+ * retrying to give time to the network stack to reset.
+ */
+static const uint16_t RestartDelay = 100; // in ticks
+
+/**
+ * Helper to call after a presumed network stack crash to wait a little bit
+ * until it completed a reset.
+ */
+inline void sleep_after_crash()
+{
+	Timeout sleep{RestartDelay};
+	thread_sleep(&sleep);
+};
+
+/**
+ * Helper to close a socket with support for network stack crashes.
+ *
+ * The close() API returns immediately with -EAGAIN if the network stack is
+ * currently resetting, hence the need for the loop. Ideally users would not
+ * have to write that helper or loop - this should be fixed in the network
+ * stack API.
+ */
+inline bool network_socket_close_retry(auto socket)
+{
+	Timeout unlimited{UnlimitedTimeout};
+	int     retries = 10;
+	for (; retries > 0; retries--)
+	{
+		int ret = network_socket_close(&unlimited, TEST_MALLOC, socket);
+		if (ret == 0)
+		{
+			return true;
+		}
+		else if (ret != -EAGAIN)
+		{
+			return false;
+		}
+		// The network stack is still resetting.
+		sleep_after_crash();
+	}
+	return false;
+};
+
+void debug_network_address(uintptr_t value, DebugWriter &writer)
+{
+	auto *address = reinterpret_cast<NetworkAddress *>(value);
+	if (address->kind == NetworkAddress::AddressKindIPv6)
+	{
+		for (int i = 0; i < 14; i += 2)
+		{
+			writer.write_hex_byte(address->ipv6[i]);
+			writer.write_hex_byte(address->ipv6[i + 1]);
+			writer.write(':');
+		}
+		writer.write_hex_byte(address->ipv6[14]);
+		writer.write_hex_byte(address->ipv6[15]);
+	}
+	else if (address->kind == NetworkAddress::AddressKindIPv4)
+	{
+		writer.write_decimal((address->ipv4 >> 0) & 0xff);
+		writer.write('.');
+		writer.write_decimal((address->ipv4 >> 8) & 0xff);
+		writer.write('.');
+		writer.write_decimal((address->ipv4 >> 16) & 0xff);
+		writer.write('.');
+		writer.write_decimal((address->ipv4 >> 24) & 0xff);
+	}
+	else
+	{
+		writer.write("<invalid address>");
+	}
+};
+
+template<>
+struct DebugFormatArgumentAdaptor<NetworkAddress>
+{
+	static DebugFormatArgument construct(NetworkAddress &address)
+	{
+		return {reinterpret_cast<uintptr_t>(&address),
+		        reinterpret_cast<uintptr_t>(debug_network_address)};
+	}
+};
+
+void __cheri_compartment("compartmentalized_http_server_example") example()
+{
+	// TODO We can eliminate this object once network APIs have been ported
+	// to the new timeout API.
+	Timeout unlimited{UnlimitedTimeout};
+
+	network_start();
+
+	auto heapAtStart = heap_quota_remaining(TEST_MALLOC);
+
+	Debug::log("Starting the server.");
+
+	// If the network stack crashes, the listening socket will be closed
+	// (as will all accepted sockets). The outer loop recreates the
+	// listening socket if this happens, up until we have handled the
+	// correct number of clients.
+	uint16_t clientsCounter = 0;
+	while (clientsCounter < MaxClients)
+	{
+		Debug::log("Creating a listening socket.");
+		auto socket = network_socket_listen_tcp(
+		  &unlimited, TEST_MALLOC, STATIC_SEALED_VALUE(HTTPPort));
+
+		if (!Capability{socket}.is_valid())
+		{
+			Debug::log("Failed to create a listening socket.");
+			// This may have failed because of a network stack
+			// crash. Sleep a little bit to enable a reset.
+			sleep_after_crash();
+			continue;
+		}
+
+		Debug::log("Listening on port {}...", LISTEN_PORT);
+		while (clientsCounter < MaxClients)
+		{
+			NetworkAddress clientAddress = {0};
+			uint16_t       clientPort    = 0;
+
+			auto clientSocket = network_socket_accept_tcp(
+			  &unlimited, TEST_MALLOC, socket, &clientAddress, &clientPort);
+
+			if (!Capability{clientSocket}.is_valid())
+			{
+				Debug::log("Failed to accept a connection.");
+				sleep_after_crash();
+				break;
+			}
+
+			Debug::log("Established a connection with {}, port {}",
+			           clientAddress,
+			           static_cast<int>(clientPort));
+
+			clientsCounter++;
+
+			// Restrict the permissions we give to the receive and
+			// send compartments. The receive compartment only
+			// needs a socket that authorizes receiving and an
+			// allocator capability for allocating and freeing. The
+			// send compartment only needs a socket for sending.
+			//
+			// TODO We should also be removing the global
+			// permissions from these capabilities, but a current
+			// compiler limitation prevents us from doing so.
+			//
+			// This implementation requires four compartment
+			// switches (server -> receiver -> server -> sender ->
+			// server). We could reduce this to three (server ->
+			// receiver -> sender -> server) by sharing the sockets
+			// through shared variables and having the receive
+			// compartment call the send compartment directly.
+			struct ParsedHTTPRequest request{};
+			int                      received = http_receive_and_parse_request(
+			  network_socket_permissions_and(clientSocket, SocketPermitReceive),
+			  allocator_permissions_and(TEST_MALLOC, AllocatorPermitAllocate),
+			  &request);
+			if (received == 0)
+			{
+				// In a real system, different method types
+				// could be processed by different handlers,
+				// each with different privileges in a
+				// different compartment.
+				if (request.methodType == HTTPRequestMethodType::GET)
+				{
+					Debug::log(
+					  "Received a GET request for resource {}.",
+					  std::string_view{request.targetResource,
+					                   sizeof(request.targetResource)});
+					http_send_get_response(network_socket_permissions_and(
+					  clientSocket, SocketPermitSend));
+				}
+				else
+				{
+					Debug::log(
+					  "Received a request for an unsupported method "
+					  "type on resource {}.",
+					  std::string_view{request.targetResource,
+					                   sizeof(request.targetResource)});
+				}
+			}
+
+			Debug::log("Terminating the connection with the client.");
+			if (!network_socket_close_retry(clientSocket))
+			{
+				Debug::log("Failed to close the client socket.");
+			}
+		}
+
+		Debug::log("Closing the listening socket.");
+		if (!network_socket_close_retry(socket))
+		{
+			Debug::log("Failed to close the listening socket.");
+		}
+	}
+
+	Debug::log("Now checking for leaks.");
+	auto heapAtEnd = heap_quota_remaining(TEST_MALLOC);
+	if (heapAtEnd < heapAtStart)
+	{
+		Debug::log("Warning: The implementation leaked {} bytes (start: {} vs. "
+		           "end: {}).",
+		           heapAtStart - heapAtEnd,
+		           heapAtEnd,
+		           heapAtStart);
+	}
+	else
+	{
+		Debug::log("No leaks detected.");
+	}
+
+	Debug::log("Terminating the server.");
+}

--- a/examples/06.COMPARTMENTALIZED_HTTP_SERVER/http_server.h
+++ b/examples/06.COMPARTMENTALIZED_HTTP_SERVER/http_server.h
@@ -1,0 +1,64 @@
+#include <NetAPI.h>
+
+/**
+ * HTTP request method types.
+ */
+enum class HTTPRequestMethodType
+{
+	GET,
+	/* Placeholder for unsupported method types. */
+	UNSUPPORTED
+};
+
+static const HTTPRequestMethodType
+http_request_method_type_from_string(const char *string)
+{
+	if (strcmp(string, "GET") == 0)
+	{
+		return HTTPRequestMethodType::GET;
+	}
+	else
+	{
+		return HTTPRequestMethodType::UNSUPPORTED;
+	}
+}
+
+/**
+ * Parsed HTTP request. *Highly*-simplified for the needs of the example.
+ */
+struct ParsedHTTPRequest
+{
+	/**
+	 * Request method type.
+	 */
+	HTTPRequestMethodType methodType = HTTPRequestMethodType::UNSUPPORTED;
+	/**
+	 * Request target resource.
+	 *
+	 * This extremely simplified implementation of a URI encapsulates a
+	 * path with up to 14 ASCII characters and a null terminator.
+	 *
+	 * This is not how one would implements URIs in a real web server.
+	 */
+	char targetResource[15] = {0};
+};
+
+/**
+ * Receive an HTTP message from a given socket and parse it.
+ *
+ * Takes a socket, an allocator capability, and an HTTP request object which is
+ * filled with the parsed HTTP request on success. `request` is clobbered on
+ * failure.
+ *
+ * Returns 0 on success and a negative error code on failure.
+ */
+int __cheri_compartment("receive_compartment")
+  http_receive_and_parse_request(Socket                    socket,
+                                 AllocatorCapability       allocatorCapability,
+                                 struct ParsedHTTPRequest *request);
+
+/**
+ * Send an HTTP response to a given socket and a given request.
+ */
+void __cheri_compartment("send_compartment")
+  http_send_get_response(Socket socket);

--- a/examples/06.COMPARTMENTALIZED_HTTP_SERVER/receive_compartment.cc
+++ b/examples/06.COMPARTMENTALIZED_HTTP_SERVER/receive_compartment.cc
@@ -1,0 +1,84 @@
+#include "timeout.h"
+#include <NetAPI.h>
+#include <errno.h>
+#if __has_include(<allocator.h>)
+#	include <allocator.h>
+#endif
+#include "http_server.h"
+#include <debug.hh>
+
+using CHERI::Capability;
+
+using Debug =
+  ConditionalDebug<true, "HTTP server example test (receive compartment)">;
+
+int __cheri_compartment("receive_compartment")
+  http_receive_and_parse_request(Socket                    socket,
+                                 AllocatorCapability       allocatorCapability,
+                                 struct ParsedHTTPRequest *request)
+{
+	Timeout unlimited{UnlimitedTimeout};
+	auto [received, buffer] =
+	  network_socket_receive(&unlimited, allocatorCapability, socket);
+
+	if (Capability{buffer}.is_valid())
+	{
+		Debug::log("Received {} bytes from the client.", received);
+
+		// We assume that we have received at least enough bytes to
+		// parse the first line of the request, and fail otherwise. A
+		// real server would properly check that and wait for more
+		// bytes if needed.
+
+		int ret = -EPROTO;
+
+		// Parse the request. This is error-prone: great we are doing
+		// this in a compartment! Since this is just an example, we do
+		// not fully parse the HTTP request: just look at the method
+		// type and URI.
+		uint32_t offset = 0;
+		for (uint32_t position = 0; position < received; position++)
+		{
+			if (buffer[position] == ' ')
+			{
+				if (offset == 0)
+				{
+					// Parse the request method.
+					buffer[position]    = '\0';
+					request->methodType = http_request_method_type_from_string(
+					  reinterpret_cast<const char *>(buffer));
+					offset = position + 1;
+					continue;
+				}
+				// Parse the URI.
+				buffer[position] = '\0';
+				strncpy(request->targetResource,
+				        reinterpret_cast<char *>(buffer + offset),
+				        sizeof(request->targetResource));
+
+				ret = 0;
+				break;
+			}
+		}
+
+		int freeRet = heap_free(allocatorCapability, buffer);
+		if (freeRet != 0)
+		{
+			// This may happen if the network stack crashed: if the network
+			// stack crashes during `network_socket_receive`, `buffer` will
+			// likely be a nullptr or any untagged value, and `heap_free`
+			// will return an error when passed the invalid thing.
+			Debug::log("Failed to free receive buffer: {}", ret);
+			return freeRet;
+		}
+
+		return ret;
+	}
+	else
+	{
+		Debug::log("Failed to receive request from the client, error {}.",
+		           received);
+	}
+
+	return received;
+}

--- a/examples/06.COMPARTMENTALIZED_HTTP_SERVER/send_compartment.cc
+++ b/examples/06.COMPARTMENTALIZED_HTTP_SERVER/send_compartment.cc
@@ -1,0 +1,49 @@
+#include "timeout.h"
+#include <NetAPI.h>
+#include <debug.hh>
+#include <fail-simulator-on-error.h>
+
+using Debug =
+  ConditionalDebug<true, "HTTP server example test (send compartment)">;
+
+/**
+ * HTTP response. We always send the same response for this simplified example.
+ *
+ * Cannot be const due to type constraints of `network_socket_send`.
+ */
+static char reply[] =
+  "HTTP/1.1 200 OK\r\n"
+  "Content-type: text/html\r\n"
+  "Connection: close\r\n"
+  "\r\n"
+  "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">"
+  "<html>"
+  "<head><title>Hello from CHERIoT!</title></head>"
+  "<body><h1>It works!</h1><p>Served from a CHERIoT device.</p></body>"
+  "</html>\n";
+
+void __cheri_compartment("send_compartment")
+  http_send_get_response(Socket socket)
+{
+	Timeout          unlimited{UnlimitedTimeout};
+	constexpr size_t ToSend = sizeof(reply) - 1;
+	size_t           sent   = 0;
+	while (sent < ToSend)
+	{
+		size_t remaining = ToSend - sent;
+
+		ssize_t sentThisCall =
+		  network_socket_send(&unlimited, socket, &(reply[sent]), remaining);
+
+		if (sentThisCall >= 0)
+		{
+			Debug::log("Served {} bytes of static content.", sentThisCall);
+			sent += sentThisCall;
+		}
+		else
+		{
+			Debug::log("Send failed: {}", sentThisCall);
+			break;
+		}
+	}
+}

--- a/examples/06.COMPARTMENTALIZED_HTTP_SERVER/xmake.lua
+++ b/examples/06.COMPARTMENTALIZED_HTTP_SERVER/xmake.lua
@@ -1,0 +1,69 @@
+-- Copyright CHERIoT Contributors.
+-- SPDX-License-Identifier: MIT
+
+-- Update this to point to the location of the CHERIoT SDK
+sdkdir = path.absolute("../../../cheriot-rtos/sdk")
+
+set_project("CHERIoT Compartmentalized HTTP Server Example")
+
+includes(sdkdir)
+
+set_toolchains("cheriot-clang")
+
+includes(path.join(sdkdir, "lib"))
+includes("../../lib")
+
+option("board")
+  set_default("ibex-arty-a7-100")
+
+compartment("compartmentalized_http_server_example")
+  add_includedirs("../../include")
+  add_deps("freestanding", "TCPIP", "NetAPI")
+  add_files("http_server.cc")
+  add_rules("cheriot.network-stack.ipv6")
+
+compartment("send_compartment")
+  add_includedirs("../../include")
+  add_deps("freestanding", "TCPIP", "NetAPI")
+  add_files("send_compartment.cc")
+  add_rules("cheriot.network-stack.ipv6")
+
+compartment("receive_compartment")
+  add_includedirs("../../include")
+  add_deps("freestanding", "TCPIP", "NetAPI")
+  add_files("receive_compartment.cc")
+  add_rules("cheriot.network-stack.ipv6")
+
+firmware("06.compartmentalized_http_server_example")
+  set_policy("build.warning", true)
+  add_deps("DNS", "TCPIP", "Firewall", "NetAPI", "compartmentalized_http_server_example", "send_compartment", "receive_compartment", "atomic8", "debug")
+  on_load(function(target)
+    target:values_set("board", "$(board)")
+    target:values_set("threads", {
+      {
+        compartment = "compartmentalized_http_server_example",
+        priority = 1,
+        entry_point = "example",
+        stack_size = 0xe00,
+        trusted_stack_frames = 6
+      },
+      {
+        compartment = "TCPIP",
+        priority = 1,
+        entry_point = "ip_thread_entry",
+        stack_size = 0xe00,
+        trusted_stack_frames = 5
+      },
+      {
+        compartment = "Firewall",
+        -- Higher priority, this will be back-pressured by the message
+        -- queue if the network stack can't keep up, but we want
+        -- packets to arrive immediately.
+        priority = 2,
+        entry_point = "ethernet_run_driver",
+        stack_size = 0x1000,
+        trusted_stack_frames = 5
+      }
+    }, {expand = false})
+  end)
+

--- a/include/NetAPI.h
+++ b/include/NetAPI.h
@@ -332,7 +332,7 @@ struct NetworkReceiveResult
  *
  * The negative values will be errno values:
  *
- *  - `-EINVAL`: The socket is not valid.
+ *  - `-EINVAL`: The timeout or socket is not valid.
  *  - `-ETIMEDOUT`: The timeout was reached before data could be received.
  *  - `-ENOTCONN`: The socket is not connected.
  */
@@ -356,7 +356,7 @@ NetworkReceiveResult __cheri_compartment("TCPIP")
  * The negative values will be errno values:
  *
  *  - `-EPERM`: `buffer` and/or `length` are invalid.
- *  - `-EINVAL`: The socket is not valid.
+ *  - `-EINVAL`: The timeout or socket is not valid.
  *  - `-ETIMEDOUT`: The timeout was reached before data could be received.
  *  - `-ENOTCONN`: The socket is not connected.
  */
@@ -387,7 +387,7 @@ int __cheri_compartment("TCPIP")
  *
  *  - `-ENOMEM`: The allocation quota is insufficient to hold the packet.
  *  - `-EPERM`: The `address` and/or `port` pointers are invalid.
- *  - `-EINVAL`: The socket is not valid.
+ *  - `-EINVAL`: The timeout or socket is not valid.
  *  - `-ETIMEDOUT`: The timeout was reached before data could be received.
  *  - `-ENOTCONN`: The socket is not connected.
  */
@@ -399,8 +399,20 @@ NetworkReceiveResult __cheri_compartment("TCPIP")
                               uint16_t           *port);
 
 /**
- * Send data over a TCP socket.  This will block until the data have been sent
- * or the timeout expires.
+ * Send data over a TCP socket. This will block until the data have been queued
+ * for sending or the timeout expires.
+ *
+ * The return value is either the number of bytes queued for sending, or a
+ * negative error code.
+ *
+ * The negative values will be errno values:
+ *
+ *  - `-EPERM`: `buffer` and/or `length` are invalid.
+ *  - `-EINVAL`: The timeout or socket is not valid.
+ *  - `-ETIMEDOUT`: The timeout was reached before data could be sent.
+ *  - `-ENOMEM`: The network stack ran out of memory (quota or available
+ *               memory) to send the packet.
+ *  - `-ENOTCONN`: The socket is not connected.
  */
 ssize_t __cheri_compartment("TCPIP") network_socket_send(Timeout *timeout,
                                                          Socket   socket,
@@ -413,8 +425,19 @@ ssize_t __cheri_compartment("TCPIP") network_socket_send(Timeout *timeout,
  * authorised with `network_socket_udp_authorise_host` (the packets will be
  * silently dropped if not, there will be no error reported).
  *
- * This will block until the data have been sent or the timeout expires.  The
- * return value is the number of bytes sent or a negative error code.
+ * This will block until the data have been queued for sending or the timeout
+ * expires. The return value is the number of bytes queued for sending or a
+ * negative error code.
+ *
+ * The negative values will be errno values:
+ *
+ *  - `-EPERM`: `buffer` and/or `length` and/or `address` are invalid.
+ *  - `-EINVAL`: The timeout or socket is not valid.
+ *  - `-ETIMEDOUT`: The timeout was reached before data could be sent.
+ *  - `-ENOMEM`: The network stack ran out of memory (quota or available
+ *               memory) to send the packet.
+ *  - `-ENOTCONN`: The socket is invalid and should be closed (typically caused
+ *                 by a network stack reset).
  */
 ssize_t __cheri_compartment("TCPIP")
   network_socket_send_to(Timeout              *timeout,

--- a/include/NetAPI.h
+++ b/include/NetAPI.h
@@ -112,6 +112,25 @@ struct BindCapabilityState
 	uint16_t maximumNumberOfConcurrentTCPConnections;
 };
 
+/**
+ * Permissions on socket handles.
+ */
+enum [[clang::flag_enum]] SocketPermission
+{
+	/**
+	 * This handle may be used to send data.
+	 */
+	SocketPermitSend = (1 << 0),
+	/**
+	 * This handle may be used to receive data.
+	 */
+	SocketPermitReceive = (1 << 1),
+	/**
+	 * This handle may be used to close the socket.
+	 */
+	SocketPermitClose = (1 << 2),
+};
+
 /// Type for a bind capability
 typedef CHERI_SEALED(struct BindCapabilityState *) BindCapability;
 
@@ -264,6 +283,27 @@ Socket __cheri_compartment("TCPIP")
                      bool                isIPv6);
 
 /**
+ * Returns the permissions held by this socket handle. This is a bitmask of
+ * `SocketPermission` values.
+ */
+static inline int network_socket_permissions(Socket socket)
+{
+	return token_permissions_get(socket);
+}
+
+/**
+ * Returns a copy of `socket` with a subset of permissions.  The `permissions`
+ * argument is a bitmask of `SocketPermission` values.  The returned handle has
+ * only the permissions that are both already present on `socket` and
+ * enumerated in `permissions`.
+ */
+static inline Socket network_socket_permissions_and(Socket socket,
+                                                    int    permissions)
+{
+	return token_permissions_and(socket, permissions);
+}
+
+/**
  * Authorise a UDP socket to send packets to a specific host.  This opens a
  * firewall hole allowing the socket to send and receive packets to the host.
  *
@@ -287,8 +327,11 @@ NetworkAddress __cheri_compartment("NetAPI")
  * Close a socket.  This must be called with the same malloc capability that
  * was used to allocate the socket.
  *
+ * The socket handle must hold the permission `SocketPermitClose`.
+ *
  * Returns 0 on success, or a negative error code on failure:
  *
+ *  - -EPERM: The socket handle does not hold the permission to close.
  *  - -EINVAL: Invalid argument (the socket is not valid, the malloc capability
  *             does not match the socket, or the timeout is invalid). When
  *             -EINVAL is returned, no resources were freed and the socket was
@@ -326,12 +369,15 @@ struct NetworkReceiveResult
  * allocated with the given malloc capability, the caller is responsible for
  * freeing this buffer.
  *
+ * The socket handle must hold the permission `SocketPermitReceive`.
+ *
  * The `bytesReceived` field of the result will be negative if an error
  * occurred.  The `buffer` field will be an untagged value if no data were
  * received.
  *
  * The negative values will be errno values:
  *
+ *  - `-EPERM`: The socket handle does not hold the permission to receive data.
  *  - `-EINVAL`: The timeout or socket is not valid.
  *  - `-ETIMEDOUT`: The timeout was reached before data could be received.
  *  - `-ENOTCONN`: The socket is not connected.
@@ -346,6 +392,8 @@ NetworkReceiveResult __cheri_compartment("TCPIP")
  * data are received or the timeout expires.  If data are received, they will be
  * stored in the provided buffer.
  *
+ * The socket handle must hold the permission `SocketPermitReceive`.
+ *
  * NOTE: Callers should remove global and load permissions from `buffer` before
  * passing it to this function if they are worried about a potentially
  * compromised network stack.
@@ -355,7 +403,8 @@ NetworkReceiveResult __cheri_compartment("TCPIP")
  *
  * The negative values will be errno values:
  *
- *  - `-EPERM`: `buffer` and/or `length` are invalid.
+ *  - `-EPERM`: `buffer` and/or `length` are invalid, or the socket handle does
+ *              not hold the permission to receive data.
  *  - `-EINVAL`: The timeout or socket is not valid.
  *  - `-ETIMEDOUT`: The timeout was reached before data could be received.
  *  - `-ENOTCONN`: The socket is not connected.
@@ -372,6 +421,8 @@ int __cheri_compartment("TCPIP")
  * allocated with the given malloc capability, the caller is responsible for
  * freeing this buffer.
  *
+ * The socket handle must hold the permission `SocketPermitReceive`.
+ *
  * The `address` and `port` arguments are used to return the address and port
  * of the sender, in host byte order.  These can be null if the caller is not
  * interested in the sender's address or port.
@@ -386,7 +437,8 @@ int __cheri_compartment("TCPIP")
  * The negative values will be errno values:
  *
  *  - `-ENOMEM`: The allocation quota is insufficient to hold the packet.
- *  - `-EPERM`: The `address` and/or `port` pointers are invalid.
+ *  - `-EPERM`: The `address` and/or `port` pointers are invalid, or the socket
+ *              handle does not hold the permission to receive data.
  *  - `-EINVAL`: The timeout or socket is not valid.
  *  - `-ETIMEDOUT`: The timeout was reached before data could be received.
  *  - `-ENOTCONN`: The socket is not connected.
@@ -402,12 +454,15 @@ NetworkReceiveResult __cheri_compartment("TCPIP")
  * Send data over a TCP socket. This will block until the data have been queued
  * for sending or the timeout expires.
  *
+ * The socket handle must hold the permission `SocketPermitSend`.
+ *
  * The return value is either the number of bytes queued for sending, or a
  * negative error code.
  *
  * The negative values will be errno values:
  *
- *  - `-EPERM`: `buffer` and/or `length` are invalid.
+ *  - `-EPERM`: `buffer` and/or `length` are invalid, or the socket handle does
+ *              not hold the permission to send data.
  *  - `-EINVAL`: The timeout or socket is not valid.
  *  - `-ETIMEDOUT`: The timeout was reached before data could be sent.
  *  - `-ENOMEM`: The network stack ran out of memory (quota or available
@@ -425,13 +480,16 @@ ssize_t __cheri_compartment("TCPIP") network_socket_send(Timeout *timeout,
  * authorised with `network_socket_udp_authorise_host` (the packets will be
  * silently dropped if not, there will be no error reported).
  *
+ * The socket handle must hold the permission `SocketPermitSend`.
+ *
  * This will block until the data have been queued for sending or the timeout
  * expires. The return value is the number of bytes queued for sending or a
  * negative error code.
  *
  * The negative values will be errno values:
  *
- *  - `-EPERM`: `buffer` and/or `length` and/or `address` are invalid.
+ *  - `-EPERM`: `buffer` and/or `length` and/or `address` are invalid, or the
+ *              socket handle does not hold the permission to send data.
  *  - `-EINVAL`: The timeout or socket is not valid.
  *  - `-ETIMEDOUT`: The timeout was reached before data could be sent.
  *  - `-ENOMEM`: The network stack ran out of memory (quota or available

--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -90,11 +90,13 @@ namespace
 	}
 
 	/**
-	 * Unseal `sealedSocket` and, if it is sealed with the correct type,
-	 * pass it to `operation`. This is a helper function used for
-	 * operations on sockets.
+	 * Unseal `sealedSocket` and, if it has all the given permissions and
+	 * is sealed with the correct type, pass it to `operation`. This is a
+	 * helper function used for operations on sockets.
 	 *
 	 * This function will return a negative code on error:
+	 *
+	 * `-EPERM` if the socket handle does not have the given permissions;
 	 *
 	 * `-EINVAL` if the unsealing fails;
 	 *
@@ -108,10 +110,16 @@ namespace
 	 */
 	int with_sealed_socket(FunctionWrapper<int(SealedSocket *socket)> operation,
 	                       Sealed<SealedSocket> sealedSocket,
+	                       int                  permissions,
 	                       bool                 isCloseOperation = false)
 	{
 		return with_restarting_checks(
 		  [&]() {
+			  if ((network_socket_permissions(sealedSocket) & permissions) !=
+			      permissions)
+			  {
+				  return -EPERM;
+			  }
 			  auto *socket = token_unseal(socket_key(), sealedSocket);
 			  if (socket == nullptr)
 			  {
@@ -147,7 +155,8 @@ namespace
 	 */
 	int with_sealed_socket(Timeout                                   *timeout,
 	                       FunctionWrapper<int(SealedSocket *socket)> operation,
-	                       Sealed<SealedSocket> sealedSocket)
+	                       Sealed<SealedSocket> sealedSocket,
+	                       int                  permissions)
 	{
 		return with_sealed_socket(
 		  [&](SealedSocket *socket) {
@@ -157,7 +166,8 @@ namespace
 			  }
 			  return -ETIMEDOUT;
 		  },
-		  sealedSocket);
+		  sealedSocket,
+		  permissions);
 	}
 
 	/**
@@ -338,7 +348,8 @@ namespace
 			  } while (timeout->may_block());
 			  return -ETIMEDOUT;
 		  },
-		  sealedSocket);
+		  sealedSocket,
+		  SocketPermitReceive);
 	}
 
 	/**
@@ -725,7 +736,8 @@ Socket network_socket_accept_tcp(Timeout            *timeout,
 		  socket = sealedSocket;
 		  return 0;
 	  },
-	  sealedListeningSocket);
+	  sealedListeningSocket,
+	  0 /* No specific permission required */);
 	return socket;
 }
 
@@ -776,7 +788,8 @@ int network_socket_connect_tcp_internal(Timeout       *timeout,
 				  return -ETIMEDOUT;
 		  }
 	  },
-	  socket);
+	  socket,
+	  0 /* No specific permission required */);
 }
 
 Socket network_socket_udp(Timeout            *timeout,
@@ -977,6 +990,7 @@ int network_socket_close(Timeout            *t,
 		  return -ETIMEDOUT;
 	  },
 	  sealedSocket,
+	  SocketPermitClose,
 	  true /* this is a close operation */);
 }
 
@@ -992,7 +1006,7 @@ network_socket_receive_from(Timeout            *timeout,
 	{
 		return {-EINVAL, buffer};
 	}
-	ssize_t  result = with_sealed_socket(
+	ssize_t result = with_sealed_socket(
 	  timeout,
 	  [&](SealedSocket *socket) {
 		  freertos_sockaddr remoteAddress;
@@ -1079,7 +1093,8 @@ network_socket_receive_from(Timeout            *timeout,
 		  }
 		  return received; // We had `received` == 0.
 	  } /* with_sealed_socket */,
-	  socket);
+	  socket,
+	  SocketPermitReceive);
 	return {result, buffer};
 }
 
@@ -1216,7 +1231,8 @@ ssize_t network_socket_send(Timeout *timeout,
 		  Debug::log("Send failed with unexpected error: {}", ret);
 		  return -EINVAL;
 	  },
-	  socket);
+	  socket,
+	  SocketPermitSend);
 }
 
 ssize_t network_socket_send_to(Timeout              *timeout,
@@ -1293,7 +1309,8 @@ ssize_t network_socket_send_to(Timeout              *timeout,
 		  Debug::log("Send failed with unexpected error: {}", ret);
 		  return -EINVAL;
 	  },
-	  socket);
+	  socket,
+	  SocketPermitSend);
 }
 
 int network_socket_kind(Socket socket, SocketKind *kind)
@@ -1318,5 +1335,6 @@ int network_socket_kind(Socket socket, SocketKind *kind)
 		    (&((socket->socket)->xBoundSocketListItem)));
 		  return 0;
 	  },
-	  socket);
+	  socket,
+	  0 /* No specific permission required */);
 }

--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -988,6 +988,10 @@ network_socket_receive_from(Timeout            *timeout,
                             uint16_t           *port)
 {
 	uint8_t *buffer = nullptr;
+	if (!check_timeout_pointer(timeout))
+	{
+		return {-EINVAL, buffer};
+	}
 	ssize_t  result = with_sealed_socket(
 	  timeout,
 	  [&](SealedSocket *socket) {


### PR DESCRIPTION
This addresses #91. While at it, it adds some missing documentation (which I realized while documenting the feature), and adds a missing check (which I found out while adding the permission checks).

This comes with a new example to showcase the use of least-privilege socket handles.