### PR TITLE
Fix firewall ipv4filter

### DIFF
--- a/lib/firewall/firewall.cc
+++ b/lib/firewall/firewall.cc
@@ -668,7 +668,7 @@ namespace
 				[[fallthrough]];
 			case IPProtocolNumber::TCP:
 			{
-				if (ipv4Header->body_offset() < sizeof(ipv4Header))
+				if (ipv4Header->body_offset() < sizeof(*ipv4Header))
 				{
 					Debug::log("Body offset is {} but IPv4 header is {} bytes",
 					           ipv4Header->body_offset(),


### PR DESCRIPTION
Fixed the issue described in [#96](https://github.com/CHERIoT-Platform/network-stack/issues/96#issue-4853043861) by changing 'sizeof(ipv4Header)' to 'sizeof(*ipv4Header)'.