### PR TITLE
Refactor the SNTP compartment to use the new clocks interface.

### DIFF
--- a/include/sntp.h
+++ b/include/sntp.h
@@ -11,6 +11,18 @@
 #include <stdint.h>
 #include <timeout.h>
 
+#if __has_include(<sys/time.h>)
+#	include <time.h>
+/**
+ * If the RTOS supports pluggable time sources, provide a compatibility version
+ * of the old API that set them.
+ */
+static inline int sntp_update(TimeoutArgument timeout)
+{
+	return clock_update_wall_clock(timeout);
+}
+#else
+
 typedef int64_t  time_t;      // NOLINT
 typedef uint32_t suseconds_t; // NOLINT
 
@@ -95,3 +107,4 @@ static inline time_t time(time_t *tloc)
 	}
 	return tv.tv_sec;
 }
+#endif

--- a/lib/sntp/include/sntp_rtc.hh
+++ b/lib/sntp/include/sntp_rtc.hh
@@ -1,0 +1,34 @@
+#pragma once
+// Don't try to do clang-tidy on this file if it won't compile.
+#if __has_include(<sys/time.h>)
+#	include <platform/concepts/wall_clock_source.hh>
+#	include <sys/time.h>
+#	include <time.h>
+
+/**
+ * Fetch the time with SNTP and return the result in `outTime`.
+ */
+int __cheri_compartment("SNTP") sntp_update(TimeoutArgument timeout,
+                                            clock_t        &outTime,
+                                            clock_t        &outMonotonicTime);
+
+struct SNTPWallClockSource
+{
+	/// SNTP fetches the time, it does not set it.
+	static constexpr bool SupportsTimeSetting = false;
+	/// SNTP requires network fetches, it is not cheap.
+	static constexpr bool IsCheap = false;
+
+	inline int get_time(TimeoutArgument timeout,
+	                    clock_t        &outRealTime,
+	                    clock_t        &outMonotonicTime,
+	                    int            &outPriority)
+	{
+		outPriority = 1000;
+		return sntp_update(timeout, outRealTime, outMonotonicTime);
+	}
+};
+
+static_assert(IsWallClockSource<SNTPWallClockSource>,
+              "The SNTP wall-clock source must implement the required concept");
+#endif

--- a/lib/sntp/sntp.cc
+++ b/lib/sntp/sntp.cc
@@ -24,6 +24,11 @@
 #include <stdlib.h>
 #include <tick_macros.h>
 
+#if __has_include(<sys/time.h>)
+#	include "include/sntp_rtc.hh"
+#	define NEW_TIME_APIS
+#endif
+
 using CHERI::Capability;
 
 using Debug = ConditionalDebug<false, "NTP Client">;
@@ -86,6 +91,7 @@ namespace
 		  context->timeout, socket, CONNECTION_CAPABILITY(ntpPool));
 		if (address.kind == NetworkAddress::AddressKindInvalid)
 		{
+			Debug::log("Failed to authorise socket, returning -ENOTCONN");
 			Timeout unlimited{UnlimitedTimeout};
 			network_socket_close(&unlimited, MALLOC_CAPABILITY, socket);
 			context->timeout->elapse(unlimited.elapsed);
@@ -207,13 +213,17 @@ namespace
 	              "Year is wrong");
 
 	/**
-	 * The current time in NTP format.
+	 * The time in NTP format of the last time update.
 	 */
 	SntpTimestamp_t currentTime = {epoch_year_approximate(), 0};
+
+	/// The monotonic time at the time `currentTime` was believed correct.
+	uint64_t currentMonotonicTime = 0;
 
 	/// NTP era, used to handle 32-bit overflow in NTP timestamps.
 	uint32_t ntpEra = epoch_year_approximate() >> 32;
 
+#ifndef NEW_TIME_APIS
 	/**
 	 * Convert an NTP timestamp to a POSIX timeval.
 	 */
@@ -237,7 +247,7 @@ namespace
 	/**
 	 * Update the current UNIX time to reflect the last cached NTP time.
 	 */
-	void unix_time_update(uint64_t cycles)
+	void unix_time_update()
 	{
 		auto &currentUNIXTime =
 		  *SHARED_OBJECT_WITH_PERMISSIONS(SynchronisedTime,
@@ -252,13 +262,14 @@ namespace
 		  "Current time: {}.{}", currentTime.seconds, currentTime.fractions);
 		currentUNIXTime.updatingEpoch++;
 		ntp_date_to_timeval(currentUNIXTime, currentTime, ntpEra);
-		currentUNIXTime.cycles = cycles;
+		currentUNIXTime.cycles = currentMonotonicTime;
 		currentUNIXTime.updatingEpoch++;
 		Debug::log("Updated UNIX time");
 		Debug::log("Current UNIX time: {}.{}",
 		           static_cast<uint64_t>(currentUNIXTime.seconds),
 		           currentUNIXTime.microseconds);
 	}
+#endif
 
 	/**
 	 * Callback to get the current NTP time.
@@ -329,10 +340,9 @@ namespace
 		currentTime.seconds = 0;
 		// As a very rough approximation, assume that the server time is
 		// accurate at the midway point of the request.
-		uint64_t cycleTime =
+		currentMonotonicTime =
 		  ntpRequestStart + ((ntpRequestEnd - ntpRequestStart) / 2);
 		currentTime = *pServerTime;
-		unix_time_update(cycleTime);
 	}
 
 	/**
@@ -341,7 +351,7 @@ namespace
 	 * FIXME: There should be a hook for integrators to use the authentication
 	 * API and provide their own time server.
 	 */
-	int ntp_time_update(Timeout *timeout)
+	int ntp_time_update(Timeout *timeout, auto update = []() {})
 	{
 		NetworkContext udpContext{timeout, nullptr};
 		SntpStatus_t   status;
@@ -430,11 +440,13 @@ namespace
 				{
 					Debug::log("Failed to receive SNTP time response: {}",
 					           status);
+					Debug::log("Tried for {} ticks", timeout->elapsed);
 					break;
 				}
 
 				Debug::log("Received new time from NTP!");
 				status = SntpSuccess;
+				update();
 			}
 			else
 			{
@@ -450,14 +462,47 @@ namespace
 
 } // namespace
 
+#if __has_include(<sys/time.h>)
+int sntp_update(TimeoutArgument timeout,
+                clock_t        &outTime,
+                clock_t        &outMonotonicTime)
+{
+	Debug::log("Trying to fetch NTP time");
+	if (!timeout.is_valid())
+	{
+		Debug::log("Invalid timeout pointer: {}", timeout);
+		return -EINVAL;
+	}
+	auto update = [&]() {
+		outMonotonicTime = currentMonotonicTime;
+		clock_t seconds  = currentTime.seconds - SNTP_TIME_AT_UNIX_EPOCH_SECS;
+		seconds *= CPU_TIMER_HZ;
+		clock_t fractions = currentTime.fractions;
+		fractions *= CPU_TIMER_HZ;
+		fractions >>= 32;
+		outTime = seconds; //+ fractions;
+		Debug::log("Fetched NTP time {} for monotonic time {}",
+		           outTime,
+		           outMonotonicTime);
+	};
+	// Note: Using .relativeTimeout here is slightly misleading, but it avoids
+	// needing to propagate knowledge of the union down to code that needs to
+	// work with older versions of the RTOS.
+	// FIXME: Remove when this file is updated to use TimeoutArguments
+	// everywhere.
+	return ntp_time_update(timeout.relativeTimeout, update);
+}
+
+#else
 int sntp_update(Timeout *timeout)
 {
+	Debug::log("Calling the wrong NTP time");
 	if (!check_timeout_pointer(timeout))
 	{
 		Debug::log("Invalid timeout pointer: {}", timeout);
 		return -EINVAL;
 	}
-	return ntp_time_update(timeout);
+	return ntp_time_update(timeout, unix_time_update);
 }
 
 int sntp_time_set_unix(Timeout *timeout, time_t time)
@@ -474,8 +519,10 @@ int sntp_time_set_unix(Timeout *timeout, time_t time)
 		currentTime.seconds   = ntpTime & 0xffffffff;
 		currentTime.fractions = 0;
 		ntpEra                = ntpTime >> 32;
-		unix_time_update(rdcycle64());
+		currentMonotonicTime  = rdcycle64();
+		unix_time_update();
 		return 0;
 	}
 	return -ETIMEDOUT;
 }
+#endif

--- a/lib/sntp/time-helpers.cc
+++ b/lib/sntp/time-helpers.cc
@@ -1,12 +1,14 @@
 // Copyright SCI Semiconductor and CHERIoT Contributors.
 // SPDX-License-Identifier: MIT
 
-#include <compartment-macros.h>
-#include <cstdint>
-#include <debug.hh>
-#include <futex.h>
-#include <riscvreg.h>
-#include <sntp.h>
+#if !__has_include(<sys/time.h>)
+
+#	include <compartment-macros.h>
+#	include <cstdint>
+#	include <debug.hh>
+#	include <futex.h>
+#	include <riscvreg.h>
+#	include <sntp.h>
 
 using Debug = ConditionalDebug<false, "Time helper">;
 
@@ -23,18 +25,12 @@ int timeval_calculate(struct timeval *__restrict tp)
 	struct timeval time;
 	uint64_t       cycles;
 	uint32_t       epoch;
-	// Is the epoch currently updating?  This is factored out to a separate
-	// variable because the clang static analyser does not spot that the two
-	// expressions on epoch are identical and so can't be both true and false
-	// at the same time.
-	bool epochIsUpdating;
 	do
 	{
-		epoch           = atomic_load(&sntpTime->updatingEpoch);
-		epochIsUpdating = epoch & 0x1;
+		epoch = atomic_load(&sntpTime->updatingEpoch);
 		// If the low bit is set then the time is being updated.  Wait for the
 		// update to finish.
-		if (epochIsUpdating)
+		if (epoch & 0x1)
 		{
 			Debug::log("Waiting for SNTP update");
 			// Wait for the update to finish
@@ -44,10 +40,10 @@ int timeval_calculate(struct timeval *__restrict tp)
 		time.tv_sec  = sntpTime->seconds;
 		time.tv_usec = sntpTime->microseconds;
 		cycles       = sntpTime->cycles;
-	} while (epochIsUpdating || epoch != atomic_load(&sntpTime->updatingEpoch));
+	} while (epoch != atomic_load(&sntpTime->updatingEpoch));
 	Debug::log(
 	  "Got raw time {}.{}", static_cast<uint64_t>(time.tv_sec), time.tv_usec);
-	uint64_t now = rdcycle64();
+	uint64_t now = platform_monotonic_time_read();
 	Debug::log(
 	  "Elapsed cycles {} (now: {}, timestamp: {}", now - cycles, now, cycles);
 	// Elapsed time in cycles
@@ -68,3 +64,4 @@ int timeval_calculate(struct timeval *__restrict tp)
 	*tp          = time;
 	return 0;
 }
+#endif

--- a/lib/sntp/xmake.lua
+++ b/lib/sntp/xmake.lua
@@ -1,6 +1,20 @@
 library("time_helpers")
   set_default(false)
   add_includedirs("../../include")
+  -- If this is a version of the RTOS that has the clock_helpers target, just
+  -- use that instead of our versions.
+  -- FIXME: This is transitional code and this library can be removed once all
+  -- users have upgraded the RTOS version.
+  after_load(function(target)
+	  import("core.project.project")
+	  local clock_helpers = project.target("clock_helpers")
+	  if (clock_helpers) then
+		  print("Adding dependency on clock_helpers compartment");
+		  target:add("deps", "clock_helpers")
+	  else
+		  print("Did not find clock_helpers compartment")
+	  end
+  end)
   add_files("time-helpers.cc")
 
 debugOption("SNTP")
@@ -14,6 +28,23 @@ compartment("SNTP")
   add_cflags("-DCHERIOT_CUSTOM_DEFAULT_MALLOC_CAPABILITY")
   add_files("../../third_party/coreSNTP/source/core_sntp_client.c",
             "../../third_party/coreSNTP/source/core_sntp_serializer.c")
+  -- If this is a version of the RTOS that has the wall_clock target, we want
+  -- to add our interface to that and not expose the other interfaces.
+  -- FIXME: This is transitional code and not required once all users have
+  -- upgraded the RTOS version.
+  after_load(function(target)
+	  import("core.project.project")
+	  local wall_clock = project.target("wall_clock")
+	  if (wall_clock) then
+		  print("Adding dependency on wall-clock compartment");
+		  target:add("deps", "wall_clock")
+		  wall_clock:add("includedirs", path.join(target:scriptdir(), "include"))
+		  wall_clock:add("cheriot.clock_source_includes", "sntp_rtc.hh")
+		  wall_clock:add("cheriot.clock_source_types", "SNTPWallClockSource")
+	  else
+		  print("Did not find wall-clock compartment")
+	  end
+  end)
   on_load(function(target)
     target:values_set("shared_objects", { sntp_time_at_last_sync = 24 }, {expand = false})
   end)


### PR DESCRIPTION
This is defined in CHERIoT-Platform/cheriot-rtos#734

The changes are currently structured to allow the network stack to build against the old and new versions.  At some point, the old versions can be removed.