### PR TITLE
Fix two bugs in TCP connection termination

### DIFF
--- a/lib/firewall/firewall.cc
+++ b/lib/firewall/firewall.cc
@@ -256,15 +256,17 @@ namespace
 
 		/**
 		 * Removes an element from the table.  Does nothing if the element is
-		 * not present.
+		 * not present. Returns whether or not the element was removed.
 		 */
-		void remove(const T &element)
+		bool remove(const T &element)
 		{
 			if (SmallTableBase::remove(
 			      base(), size() * sizeof(T), &element, sizeof(T)))
 			{
 				set_size(size() - 1);
+				return true;
 			}
+			return false;
 		}
 
 		/**
@@ -504,7 +506,7 @@ namespace
 			tcpServerPorts.clear();
 		}
 
-		void remove_endpoint(IPProtocolNumber protocol,
+		bool remove_endpoint(IPProtocolNumber protocol,
 		                     Address          endpoint,
 		                     uint16_t         localPort,
 		                     uint16_t         remotePort)
@@ -516,7 +518,7 @@ namespace
 			auto guardedTable = permitted_endpoints(protocol);
 			auto &[g, table]  = guardedTable;
 			ConnectionTuple tuple{endpoint, localPort, remotePort};
-			table.remove(tuple);
+			return table.remove(tuple);
 		}
 
 		void add_server_port(uint16_t localPort)
@@ -1030,10 +1032,12 @@ void firewall_remove_tcpipv4_remote_endpoint(uint32_t remoteAddress,
                                              uint16_t localPort,
                                              uint16_t remotePort)
 {
-	EndpointsTable<uint32_t>::instance().remove_endpoint(
-	  IPProtocolNumber::TCP, remoteAddress, localPort, remotePort);
-	if (EndpointsTable<uint32_t>::instance().is_server_port(localPort))
+	if (EndpointsTable<uint32_t>::instance().remove_endpoint(
+	      IPProtocolNumber::TCP, remoteAddress, localPort, remotePort) &&
+	    EndpointsTable<uint32_t>::instance().is_server_port(localPort))
 	{
+		// Decrease the number of clients only if we actually removed
+		// an entry from the endpoints table.
 		currentClientCount--;
 	}
 }

--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -415,16 +415,10 @@ namespace
  * an attempted three-way-handshake failed. We can use it to tell the firewall
  * to remove the hole.
  *
- * It is also worth noting that this will never be called if *we* close the
- * socket through `FreeRTOS_closesocket`.
- *
- * This is because FreeRTOS+TCP does not do a three-way handshake close when
- * the socket is closed through `FreeRTOS_socketclose()`. Instead, FreeRTOS+TCP
- * sends a FIN to the peer and destroys the socket immediately. Any further
- * packet from the peer is answered with a RST (as a spurious packet).  Because
- * the socket is destroyed in a state when the TCP connection has not been
- * properly closed (it is just in the "FIN sent" stage, i.e., FIN Wait-1), the
- * callback is not called.
+ * Note that this may or may not be called if *we* close the socket through
+ * `FreeRTOS_closesocket`: if the remote peer does not complete the termination
+ * handshake or if our timeout runs out, the connection may be left dangling,
+ * in which case this callback will not be called.
  */
 static void on_tcp_connect(Socket_t socket, BaseType_t isConnected)
 {
@@ -841,11 +835,44 @@ int network_socket_close(Timeout            *t,
 			  {
 				  auto rawSocket = socket->socket;
 
-				  // Do not bother with the return value:
-				  // `FreeRTOS_shutdown` fails if the TCP
+				  // Nothing to do if `FreeRTOS_shutdown`
+				  // fails: this happens only if the TCP
 				  // connection is dead, which is likely to
 				  // happen in practice and has no impact here.
-				  FreeRTOS_shutdown(rawSocket, FREERTOS_SHUT_RDWR);
+				  if (FreeRTOS_shutdown(rawSocket, FREERTOS_SHUT_RDWR) == 0)
+				  {
+					  // Wait for `FreeRTOS_recv` to return
+					  // ENOTCONN or EINVAL, indicating
+					  // that the connection was properly
+					  // closed. We need to do this to
+					  // allow for the TCP connection
+					  // termination handshake to happen
+					  // (otherwise we will leave the
+					  // connection dangling).
+					  bool terminated = false;
+					  do
+					  {
+						  auto ret = with_freertos_timeout(
+						    t, rawSocket, FREERTOS_SO_RCVTIMEO, [&] {
+							    return FreeRTOS_recv(socket->socket,
+							                         nullptr,
+							                         1,
+							                         FREERTOS_MSG_PEEK);
+						    });
+
+						  // `FreeRTOS_recv` can return
+						  // other error codes; we can
+						  // safely ignore them.
+						  terminated = (ret == -pdFREERTOS_ERRNO_ENOTCONN) ||
+						               (ret == -pdFREERTOS_ERRNO_EINVAL);
+
+						  if (!terminated && t->may_block())
+						  {
+							  Timeout sleep{1};
+							  thread_sleep(&sleep);
+						  }
+					  } while (!terminated && t->may_block());
+				  }
 
 				  auto localPort = htons(rawSocket->usLocalPort);
 				  if (rawSocket->bits.bIsIPv6)
@@ -866,6 +893,16 @@ int network_socket_close(Timeout            *t,
 						  // Otherwise close the
 						  // corresponding firewall
 						  // hole.
+						  //
+						  // The firewall hole may
+						  // already have been closed
+						  // by `on_tcp_connect` if the
+						  // TCP termination handshake
+						  // completed, but we cannot
+						  // be certain of it since it
+						  // depends on the remote
+						  // peer. Attempting to close
+						  // it a second time is fine.
 						  if (rawSocket->u.xTCP.eTCPState == eTCP_LISTEN)
 						  {
 							  firewall_remove_tcpipv6_server_port(localPort);


### PR DESCRIPTION
- Our implementation of `network_socket_close` was racy, which caused it to leave TCP connections dangling after closing a socket. This probably fixes https://github.com/CHERIoT-Platform/network-stack/issues/56.
- Calling `firewall_remove_tcpipv4_remote_endpoint` twice on the same endpoint resulted in bricking the firewall (BAD). This bug was hidden by the first bug.

@davidchisnall Not sure if 1 tick is the right time to wait between two calls to `FreeRTOS_recv`. In my measurements, I never needed more than a single call, so never had to wait.