### PR TITLE
Firewall: fix the maximum TCP client count check

### DIFF
--- a/lib/firewall/firewall.cc
+++ b/lib/firewall/firewall.cc
@@ -746,7 +746,7 @@ namespace
 					    ((ntohs(tcpHeader->bitfield) & TCPBitfieldACKMask) ==
 					     0))
 					{
-						if (currentClientCount + 1 >=
+						if (currentClientCount + 1 >
 						    FirewallMaximumNumberOfClients)
 						{
 							// Maximum number of client connections


### PR DESCRIPTION
The firewall currently rejects a new TCP connection when accepting it would make the client count greater or equal to the defined maximum. As a result, a maximum of 6 clients allows only 5.
Changed the filtering logic to reject a connection only when accepting it would exceed the configured maximum.