### PR TITLE
Fixed with_sealed_socket UAF issue

### DIFF
--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -120,7 +120,7 @@ namespace
 			  }
 			  /*
 			   * We are not holding the socket lock here, but still doing
-			   * deference of the socket, which can lead to an UAF error.
+			   * dereference of the socket, which can lead to an UAF error.
 			   * To address this, we use ephemeral call before dereferencing
 			   * the socket.
 			   */
@@ -128,8 +128,8 @@ namespace
 			    heap_claim_ephemeral(TimeoutWaitForever, socket, nullptr);
 			  if (result != 0)
 			  {
-				  /**
-				   * The result cannot be -ETIMEOUT, since we have unlimited
+				  /*
+				   * The result cannot be -ETIMEDOUT, since we have unlimited
 				   * timeout. Return -EINVAL if socket is neither null nor a
 				   * valid pointer at the end.
 				   */

--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -118,6 +118,23 @@ namespace
 				  Debug::log("Failed to unseal socket");
 				  return -EINVAL;
 			  }
+			  /*
+			   * We are not holding the socket lock here, but still doing
+			   * deference of the socket, which can lead to an UAF error.
+			   * To address this, we use ephemeral call before dereferencing
+			   * the socket.
+			   */
+			  int result =
+			    heap_claim_ephemeral(TimeoutWaitForever, socket, nullptr);
+			  if (result != 0)
+			  {
+				  /**
+				   * The result cannot be -ETIMEOUT, since we have unlimited
+				   * timeout. Return -EINVAL if socket is neither null nor a
+				   * valid pointer at the end.
+				   */
+				  return result;
+			  }
 			  if (socket->socketEpoch != currentSocketEpoch.load())
 			  {
 				  Debug::log(


### PR DESCRIPTION
This PR partially addresses issue #104. It adds an ephemeral claim in `with_sealed_socket()` to prevent a Use-After-Free when the socket is dereferenced before acquiring its lock. The remaining case mentioned in #104 that needs to be fixed is in `network_socket_close()`, where we need another ephemeral claim to prevent a Use-After-Free if the lock has already been destroyed during a reset.