### PR TITLE
Add multi-waiter support for TCP accept

### DIFF
--- a/include/NetAPI.h
+++ b/include/NetAPI.h
@@ -40,8 +40,12 @@ struct NetworkAddress
  */
 enum SocketEventType : uint8_t
 {
-	SocketAcceptEvent = 0, // Triggered when a new TCP connection is accepted on
-	                       // a listening socket
+	/// Triggered when a new TCP connection
+	/// is accepted on a listening socket.
+	/// The value of the futex corresponding to
+	/// SocketAcceptEvent, means the number of
+	/// pending connections.
+	SocketAcceptEvent = 0,
 	// SocketReceiveEvent = 1, // Triggered when data is received on a socket
 	// SocketSendEvent = 2     // Triggered when a socket has space available
 	// for sending

--- a/include/NetAPI.h
+++ b/include/NetAPI.h
@@ -35,6 +35,25 @@ struct NetworkAddress
 };
 
 /**
+ * Enumeration that defines futex types. Each value corresponds
+ * to an index in the socket's futex array.
+ */
+enum SocketEventType : uint8_t
+{
+	SocketAcceptEvent = 0, // Triggered when a new TCP connection is accepted on
+	                       // a listening socket
+	// SocketReceiveEvent = 1, // Triggered when data is received on a socket
+	// SocketSendEvent = 2     // Triggered when a socket has space available
+	// for sending
+};
+
+/// Number of distinct socket event futex types.
+static constexpr size_t NumFutexTypes = SocketEventType::SocketAcceptEvent + 1;
+/// Sentinel value stored in a socket event futex after the socket has been
+/// torn down.
+static constexpr uint32_t SocketNotAvailable = -1;
+
+/**
  * Enumeration defining the connection type.
  */
 enum ConnectionType : uint8_t
@@ -268,6 +287,14 @@ Socket __cheri_compartment("TCPIP")
   network_socket_udp(Timeout            *timeout,
                      AllocatorCapability mallocCapability,
                      bool                isIPv6);
+
+/**
+ * Return the event source associated with a socket.
+ *
+ * The returned capability is read-only and bounded to four bytes.
+ */
+uint32_t *__cheri_compartment("TCPIP")
+  network_socket_get_event_source(Socket sealedSocket, SocketEventType type);
 
 /**
  * Authorise a UDP socket to send packets to a specific host.  This opens a

--- a/include/NetAPI.h
+++ b/include/NetAPI.h
@@ -51,7 +51,7 @@ enum SocketEventType : uint8_t
 static constexpr size_t NumFutexTypes = SocketEventType::SocketAcceptEvent + 1;
 /// Sentinel value stored in a socket event futex after the socket has been
 /// torn down.
-static constexpr uint32_t SocketNotAvailable = -1;
+static constexpr int32_t SocketNotAvailable = INT32_MIN;
 
 /**
  * Enumeration defining the connection type.

--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -715,6 +715,13 @@ Socket network_socket_accept_tcp(Timeout            *timeout,
 		  }
 
 		  socketWrapper->socketEpoch = currentSocketEpoch.load();
+		  /*
+		   * For the newly allocated child socket, initialize the futexes.
+		   */
+		  for (auto &eventState : socketWrapper->eventFutexState)
+		  {
+			  eventState.store(0);
+		  }
 
 		  struct freertos_sockaddr addressTmp;
 		  uint32_t                 addressLength = sizeof(addressTmp);
@@ -798,6 +805,7 @@ Socket network_socket_accept_tcp(Timeout            *timeout,
 			  token_obj_destroy(mallocCapability, socket_key(), sealedSocket);
 			  return -EINVAL;
 		  }
+		  xSocketSetSocketID(rawSocket, socketWrapper);
 
 		  // Set `address`.
 		  if ((heap_claim_ephemeral(timeout, address) < 0) ||

--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -425,6 +425,12 @@ int SealedSocket::signal_event_futex(SocketEventType type)
 	uint32_t current = futex.load();
 	while (current != SocketNotAvailable)
 	{
+		/*
+		 * If the futex's current value equals current,
+		 * store current + 1 and return true. Otherwise
+		 * write the actual current value into current
+		 * (by reference) and return false.
+		 */
 		if (futex.compare_exchange_strong(current, current + 1))
 		{
 			futex.notify_all();
@@ -435,10 +441,6 @@ int SealedSocket::signal_event_futex(SocketEventType type)
 	return -EINVAL;
 }
 
-/**
- * The caller must hold socketLock, which prevents the SealedSocket from being
- * deallocated while this method accesses the futex.
- */
 int SealedSocket::consume_event_futex(SocketEventType type)
 {
 	auto    &futex   = eventFutexState[type];

--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -422,7 +422,7 @@ int SealedSocket::signal_event_futex(SocketEventType type)
 	{
 		return -EINVAL;
 	}
-	uint32_t current = futex.load();
+	int32_t current = futex.load();
 	while (current != SocketNotAvailable)
 	{
 		/*
@@ -443,9 +443,9 @@ int SealedSocket::signal_event_futex(SocketEventType type)
 
 int SealedSocket::consume_event_futex(SocketEventType type)
 {
-	auto    &futex   = eventFutexState[type];
-	uint32_t current = futex.load();
-	while (current != SocketNotAvailable && current != 0)
+	auto   &futex   = eventFutexState[type];
+	int32_t current = futex.load();
+	while (current != SocketNotAvailable)
 	{
 		if (futex.compare_exchange_strong(current, current - 1))
 		{
@@ -453,7 +453,7 @@ int SealedSocket::consume_event_futex(SocketEventType type)
 		}
 	}
 
-	return (current == SocketNotAvailable) ? -EINVAL : 0;
+	return -EINVAL;
 }
 
 /**
@@ -933,18 +933,17 @@ uint32_t *network_socket_get_event_source(Socket          sealedSocket,
 	{
 		with_sealed_socket(
 		  [&](SealedSocket *socket) {
-			  auto *futex =
-			    reinterpret_cast<uint32_t *>(&socket->eventFutexState[type]);
+			  auto *futex = &socket->eventFutexState[type];
 
-			  Capability readyOnlyEventSource{futex};
-			  // Restrict the capability to read-only so the futex can only be
-			  // modified through the callback, not by the caller of this
-			  // helper.
-			  readyOnlyEventSource.bounds() = sizeof(uint32_t);
-			  readyOnlyEventSource.permissions() &=
+			  Capability readOnlyEventSource{futex};
+			  // Expose the futex as read-only. The caller may observe its raw
+			  // 32-bit representation but may modify it only through the
+			  // socket callbacks.
+			  readOnlyEventSource.bounds() = sizeof(*futex);
+			  readOnlyEventSource.permissions() &=
 			    {Permission::Load, Permission::Global};
 
-			  result = readyOnlyEventSource.get();
+			  result = reinterpret_cast<uint32_t *>(readOnlyEventSource.get());
 			  return 0;
 		  },
 		  sealedSocket);

--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -412,7 +412,47 @@ namespace
 
 		return ret;
 	}
+
 } // namespace
+
+int SealedSocket::signal_event_futex(SocketEventType type)
+{
+	auto &futex = eventFutexState[type];
+	if (heap_claim_ephemeral(TimeoutWaitForever, &futex) != 0)
+	{
+		return -EINVAL;
+	}
+	uint32_t current = futex.load();
+	while (current != SocketNotAvailable)
+	{
+		if (futex.compare_exchange_strong(current, current + 1))
+		{
+			futex.notify_all();
+			return 0;
+		}
+	}
+
+	return -EINVAL;
+}
+
+/**
+ * The caller must hold socketLock, which prevents the SealedSocket from being
+ * deallocated while this method accesses the futex.
+ */
+int SealedSocket::consume_event_futex(SocketEventType type)
+{
+	auto    &futex   = eventFutexState[type];
+	uint32_t current = futex.load();
+	while (current != SocketNotAvailable && current != 0)
+	{
+		if (futex.compare_exchange_strong(current, current - 1))
+		{
+			return 0;
+		}
+	}
+
+	return (current == SocketNotAvailable) ? -EINVAL : 0;
+}
 
 /**
  * Callback called by FreeRTOS+TCP when a TCP connection is created or
@@ -468,6 +508,24 @@ static void on_tcp_connect(Socket_t socket, BaseType_t isConnected)
 			  address.sin_address.ulIP_IPv4, localPort, address.sin_port);
 		}
 	}
+	else
+	{
+		// Update eventFutexState in the listening socket and wake up the
+		// threads sleeping on the corresponding futex.
+		// Use the FreeRTOS getter to get the wrapper capability we stored in
+		// it.
+		auto *wrapper =
+		  static_cast<SealedSocket *>(pvSocketGetSocketID(socket));
+		if (wrapper != nullptr)
+		{
+			/*
+			 * Ignore the return value. If the socket has been invalidated,
+			 * the subsequent accept call will detect that it is unavailable.
+			 */
+			wrapper->signal_event_futex(SocketEventType::SocketAcceptEvent);
+		}
+		return;
+	}
 }
 F_TCP_UDP_Handler_t onTCPConnectCallback = {on_tcp_connect};
 
@@ -495,6 +553,11 @@ Socket network_socket_create_and_bind(Timeout            *timeout,
 
 		  // Set the socket epoch
 		  socketWrapper->socketEpoch = currentSocketEpoch.load();
+		  // Multi-waiter: initialize the futexes.
+		  for (auto &eventState : socketWrapper->eventFutexState)
+		  {
+			  eventState.store(0);
+		  }
 
 		  const auto Family = isIPv6 ? FREERTOS_AF_INET6 : FREERTOS_AF_INET;
 		  Socket_t   socket =
@@ -512,7 +575,14 @@ Socket network_socket_create_and_bind(Timeout            *timeout,
 			  token_obj_destroy(mallocCapability, socket_key(), sealedSocket);
 			  return -ENOMEM;
 		  }
+
+		  /*
+		   * Create a bidirectional association between the FreeRTOS socket and
+		   * the sealed socket wrapper. This is used to retrieve the sealed
+		   * socket wrapper from the FreeRTOS socket in the callbacks.
+		   */
 		  socketWrapper->socket = socket;
+		  xSocketSetSocketID(socket, socketWrapper);
 
 		  // Claim the socket so that it counts towards the caller's quota.  The
 		  // network stack also keeps a claim to it.  We will drop this claim on
@@ -673,6 +743,24 @@ Socket network_socket_accept_tcp(Timeout            *timeout,
 			  token_obj_destroy(mallocCapability, socket_key(), sealedSocket);
 			  return acceptResult;
 		  }
+		  /*
+		   * Note that here we update the futex, but no need to call
+		   * notify_all() on the waiting threads. Because the threads are
+		   * waiting on multiwaiter for arriving connected socket, but here the
+		   * semantics is not having an arrving connection. So there is no need
+		   * to wake the threads up, since they will probably find that there is
+		   * no available sockets and go back to sleep again.
+		   */
+		  int futexConsumeResult = listeningSocket->consume_event_futex(
+		    SocketEventType::SocketAcceptEvent);
+		  if (futexConsumeResult != 0)
+		  {
+			  // Return -EINVAL, which represents the
+			  // socket will be freed soon.
+			  close_socket_retry(timeout, rawSocket);
+			  token_obj_destroy(mallocCapability, socket_key(), sealedSocket);
+			  return futexConsumeResult;
+		  }
 		  socketWrapper->socket = rawSocket;
 
 		  // Claim the socket so that it counts towards the caller's quota.  The
@@ -831,6 +919,37 @@ Socket network_socket_udp(Timeout            *timeout,
 	  timeout, mallocCapability, isIPv6, ConnectionTypeUDP);
 }
 
+/**
+ * Getter to get the read only capability of a specific futex in
+ * specific socket. If the futex is invalid, return a untagged nullptr.
+ */
+uint32_t *network_socket_get_event_source(Socket          sealedSocket,
+                                          SocketEventType type)
+{
+	uint32_t *result = nullptr;
+	if (type < NumFutexTypes)
+	{
+		with_sealed_socket(
+		  [&](SealedSocket *socket) {
+			  auto *futex =
+			    reinterpret_cast<uint32_t *>(&socket->eventFutexState[type]);
+
+			  Capability readyOnlyEventSource{futex};
+			  // Restrict the capability to read-only so the futex can only be
+			  // modified through the callback, not by the caller of this
+			  // helper.
+			  readyOnlyEventSource.bounds() = sizeof(uint32_t);
+			  readyOnlyEventSource.permissions() &=
+			    {Permission::Load, Permission::Global};
+
+			  result = readyOnlyEventSource.get();
+			  return 0;
+		  },
+		  sealedSocket);
+	}
+	return result;
+}
+
 int network_socket_close(Timeout            *t,
                          AllocatorCapability mallocCapability,
                          Socket              sealedSocket)
@@ -893,6 +1012,12 @@ int network_socket_close(Timeout            *t,
 			  if (socketEpoch == currentSocketEpoch.load())
 			  {
 				  bool isTCP = rawSocket->ucProtocol == FREERTOS_IPPROTO_TCP;
+
+				  // Set the back pointer (pointing to the
+				  // wrapper) to nullptr, so that we will not
+				  // have a dangling pointer.
+				  xSocketSetSocketID(rawSocket, nullptr);
+
 				  // Nothing to do if `FreeRTOS_shutdown`
 				  // fails: this happens only if the TCP
 				  // connection is dead, which is likely to
@@ -1039,6 +1164,14 @@ int network_socket_close(Timeout            *t,
 					  // task. With some luck, the socket can be
 					  // freed next time we try.
 					  return -ETIMEDOUT;
+				  }
+				  // Wake any thread waiting on this socket's event futex so
+				  // that it does not sleep forever on memory that is about to
+				  // be freed.
+				  for (auto &eventState : socket->eventFutexState)
+				  {
+					  eventState.store(SocketNotAvailable);
+					  eventState.notify_all();
 				  }
 
 				  g.release();

--- a/lib/tcpip/tcpip-internal.h
+++ b/lib/tcpip/tcpip-internal.h
@@ -49,7 +49,7 @@ struct SealedSocket
 	 * feature. Different events increment different futexes in the array and
 	 * wake the corresponding waiting threads.
 	 */
-	std::atomic<uint32_t> eventFutexState[NumFutexTypes];
+	std::atomic<int32_t> eventFutexState[NumFutexTypes];
 	/**
 	 * Increments the futex and notifies all waiters if the futex is still
 	 * valid.
@@ -58,16 +58,17 @@ struct SealedSocket
 	 */
 	int signal_event_futex(SocketEventType type);
 	/**
-	 * Consume one pending event by decrementing the futex.
+	 * Records one successfully accepted child socket by decrementing the accept
+	 * event counter.
 	 *
 	 * The caller must hold `socketLock`, which prevents the socket from being
-	 * deallocated while the futex is accessed. This operation is only
-	 * bookkeeping: the caller has already consumed the corresponding event, so
-	 * a zero counter is not an error.
+	 * freed while the futex is accessed. The futex value may become negative
+	 * if this helper is invoked after `FreeRTOS_accept()` successfully dequeue
+	 * a child, but before `on_tcp_connect()` increment the futex. The delayed
+	 * increment will repay this temporary debt.
 	 *
-	 * Returns 0 if the futex remains valid, regardless of whether the counter
-	 * was decremented. Returns `-EINVAL` if the futex has been invalidated by
-	 * being set to `SocketNotAvailable` because the socket is being torn down.
+	 * Returns 0 on success, or `-EINVAL` if the futex has been invalidated by
+	 * being set to `SocketNotAvailable`.
 	 */
 	int consume_event_futex(SocketEventType type);
 	/**

--- a/lib/tcpip/tcpip-internal.h
+++ b/lib/tcpip/tcpip-internal.h
@@ -3,6 +3,8 @@
 
 #pragma once
 #include <FreeRTOS_IP.h>
+#include <NetAPI.h>
+#include <atomic>
 #include <ds/linked_list.h>
 #include <function_wrapper.hh>
 #include <locks.hh>
@@ -42,6 +44,14 @@ struct SealedSocket
 	 * to the current instance of the network stack.
 	 */
 	uint64_t socketEpoch;
+	/**
+	 * Event waiter source futex array. This supports the multi-waiter
+	 * feature. Different events increment different futexes in the array and
+	 * wake the corresponding waiting threads.
+	 */
+	std::atomic<uint32_t> eventFutexState[NumFutexTypes];
+	int                   signal_event_futex(SocketEventType type);
+	int                   consume_event_futex(SocketEventType type);
 	/**
 	 * The lock protecting this socket.
 	 */

--- a/lib/tcpip/tcpip-internal.h
+++ b/lib/tcpip/tcpip-internal.h
@@ -50,8 +50,26 @@ struct SealedSocket
 	 * wake the corresponding waiting threads.
 	 */
 	std::atomic<uint32_t> eventFutexState[NumFutexTypes];
-	int                   signal_event_futex(SocketEventType type);
-	int                   consume_event_futex(SocketEventType type);
+	/**
+	 * Increments the futex and notifies all waiters if the futex is still
+	 * valid.
+	 *
+	 * Returns 0 on success, or `-EINVAL` if the futex has been invalidated.
+	 */
+	int signal_event_futex(SocketEventType type);
+	/**
+	 * Consume one pending event by decrementing the futex.
+	 *
+	 * The caller must hold `socketLock`, which prevents the socket from being
+	 * deallocated while the futex is accessed. This operation is only
+	 * bookkeeping: the caller has already consumed the corresponding event, so
+	 * a zero counter is not an error.
+	 *
+	 * Returns 0 if the futex remains valid, regardless of whether the counter
+	 * was decremented. Returns `-EINVAL` if the futex has been invalidated by
+	 * being set to `SocketNotAvailable` because the socket is being torn down.
+	 */
+	int consume_event_futex(SocketEventType type);
 	/**
 	 * The lock protecting this socket.
 	 */

--- a/lib/tcpip/tcpip_error_handler.h
+++ b/lib/tcpip/tcpip_error_handler.h
@@ -195,6 +195,13 @@ extern "C" void reset_network_stack_state(bool isIpThread)
 				DebugErrorHandler::log("Ignoring corrupted socket lock {}.",
 				                       lock);
 			}
+			// Notify all threads waiting on the socket's futexes so that they
+			// do not sleep forever on this old socket.
+			for (auto &eventState : socket->eventFutexState)
+			{
+				eventState.store(SocketNotAvailable);
+				eventState.notify_all();
+			}
 
 			FreeRTOS_Socket_t *s = socket->socket;
 			if (Capability{s}.is_valid() &&


### PR DESCRIPTION
### New feature description:
Allow a single thread to wait for incoming connections across multiple
listening sockets at once using multiwaiter_wait(), instead of having to
block in network_socket_accept_tcp() on one socket at a time.

Each socket now exposes an array of futex called eventFutexState, that 
a caller can register them with a multiwaiter. For this PR, only the added
the accept functionality, others remains commented out for now. A thread 
can watch the accept futexes of several listening sockets simultaneously, 
block in multiwaiter_wait() until one of them signals a ready connection, and then 
accept that connection. The blocking wait therefore moves out of accept() and 
into the multiwaiter: accept() is called only once a connection is known to be 
ready, so it no longer has to block, which is what makes it possible to wait on 
several listening sockets at the same time from a single thread.

### Key changes:
1. Added Event futex array (tcpip-internal.h, NetAPI.h) for socket wrapper: Only
SocketAcceptEvent is implemented today, room reserved for future receive/send 
events. The value of the futex counts the ready events currently pending on the
socket. For SocketAcceptEvent, it represents the number of connections that are 
ready to be accepted. The reserved value SocketNotAvailable (INT_MIN) means the
socket will be freed soon.

2. Read-only getter: network_socket_get_event_source() returns a capability to
a socket's event futex stripped to read-only.

3. Producing events: on_tcp_connect increments the SocketAcceptEvent futex and calls
notify_all() when a new connection becomes ready. To let the callback can find
the wrapper from the raw socket, network_socket_create_and_bind() now applys 
a bidirectional link between the wrapper and raw socket.

4. Consuming events: network_socket_accept_tcp() decrements the futex after it
successfully accepts a connection. This only keeps the futex value align with the 
semantic desbribed above. It does not call notify_all(), since dequeuing an existing 
connection is not a new, so no need to wake the threads up.

5. Avoid waiting forever when socket is not available: the futex lives in the socket
wrapper's heap memory, so a thread must never be left blocked on a socket
that is being freed. Both network_socket_close() and the reset handler
(reset_network_stack_state) set every event futex to SocketNotAvailable and
call notify_all() before that memory goes away. The value change wakes any
thread blocked in multiwaiter_wait(), which then observes the sentinel and
returns instead of sleeping on a dead socket. A subsequent accept() will see the
sentinel and reports the socket as unavailable.