### PR TITLE
Firewall: keep the TCP hole open for the final ACK

### DIFF
--- a/lib/firewall/firewall.cc
+++ b/lib/firewall/firewall.cc
@@ -3,9 +3,11 @@
 
 #include <atomic>
 #include <compartment-macros.h>
+#include <cstddef>
 #include <debug.hh>
 // #include <fail-simulator-on-error.h>
 #include <endianness.hh>
+#include <errno.h>
 #include <locks.hh>
 #include <platform-entropy.hh>
 #include <platform-ethernet.hh>
@@ -37,7 +39,8 @@ namespace
 		__noinline void insert(void       *buffer,
 		                       size_t      bufferSize,
 		                       const void *element,
-		                       size_t      elementSize)
+		                       size_t      elementSize,
+		                       size_t      keySize)
 		{
 			// This currently does a linear search.  This is less code than a
 			// binary search and we don't insert on a hot path, so this should
@@ -45,7 +48,7 @@ namespace
 			for (size_t i = 0; i < bufferSize; i += elementSize)
 			{
 				void *current = reinterpret_cast<uint8_t *>(buffer) + i;
-				if (memcmp(current, element, elementSize) > 0)
+				if (memcmp(current, element, keySize) > 0)
 				{
 					memmove(reinterpret_cast<uint8_t *>(current) + elementSize,
 					        current,
@@ -66,7 +69,8 @@ namespace
 		__noinline void *binary_search(void       *buffer,
 		                               size_t      bufferSize,
 		                               const void *element,
-		                               size_t      elementSize)
+		                               size_t      elementSize,
+		                               size_t      comparisonSize)
 		{
 			if (bufferSize > 0)
 			{
@@ -77,7 +81,7 @@ namespace
 					size_t mid = low + (high - low) / 2;
 					void  *current =
 					  reinterpret_cast<uint8_t *>(buffer) + (mid * elementSize);
-					int comparison = memcmp(current, element, elementSize);
+					int comparison = memcmp(current, element, comparisonSize);
 					if (comparison == 0)
 					{
 						return current;
@@ -107,10 +111,11 @@ namespace
 		__noinline bool remove(void       *buffer,
 		                       size_t      bufferSize,
 		                       const void *element,
-		                       size_t      elementSize)
+		                       size_t      elementSize,
+		                       size_t      keySize)
 		{
 			void *found =
-			  binary_search(buffer, bufferSize, element, elementSize);
+			  binary_search(buffer, bufferSize, element, elementSize, keySize);
 			if (found == nullptr)
 			{
 				return false;
@@ -153,11 +158,11 @@ namespace
 	/**
 	 * A simple table of `T`s, stored as a sorted array.  This uses `memcmp` and
 	 * `memcpy` to compare and copy elements and so requires that `T` is a
-	 * trivial type.
+	 * trivial type.  The first `KeySize` bytes form the table key.
 	 *
 	 * This never shrinks and does a full copy if it needs to grow.
 	 */
-	template<typename T>
+	template<typename T, size_t KeySize = sizeof(T)>
 	class SmallTable : public SmallTableBase
 	{
 		static_assert(std::is_trivial_v<T>, "T must be a trivial type");
@@ -252,8 +257,11 @@ namespace
 
 			buffer = CHERI::Capability<T>{static_cast<T *>(currentBase)};
 
-			SmallTableBase::insert(
-			  currentBase, currentSize * sizeof(T), &element, sizeof(T));
+			SmallTableBase::insert(currentBase,
+			                       currentSize * sizeof(T),
+			                       &element,
+			                       sizeof(T),
+			                       KeySize);
 			set_size(currentSize + 1);
 		}
 
@@ -264,7 +272,7 @@ namespace
 		bool remove(const T &element)
 		{
 			if (SmallTableBase::remove(
-			      base(), size() * sizeof(T), &element, sizeof(T)))
+			      base(), size() * sizeof(T), &element, sizeof(T), KeySize))
 			{
 				set_size(size() - 1);
 				return true;
@@ -287,13 +295,20 @@ namespace
 		}
 
 		/**
+		 * Returns the matching element, or `nullptr` if it is not present.
+		 */
+		T *find(const T &element)
+		{
+			return static_cast<T *>(binary_search(
+			  base(), size() * sizeof(T), &element, sizeof(T), KeySize));
+		}
+
+		/**
 		 * Returns true if the table contains the given element.
 		 */
 		bool contains(const T &element)
 		{
-			return binary_search(
-			         base(), size() * sizeof(T), &element, sizeof(T)) !=
-			       nullptr;
+			return find(element) != nullptr;
 		}
 
 		/**
@@ -523,14 +538,19 @@ namespace
 			Address  remoteAddress;
 			uint16_t localPort;
 			uint16_t remotePort;
+			// Tracks whether this hole is open, closing, or safe to remove.
+			TCPFirewallState state;
 			// A clang-tidy bug thinks that this should be = nullptr instead of
 			// = default.
 			auto operator<=>(const ConnectionTuple &) const = default; // NOLINT
 		};
-		SmallTable<uint16_t>        tcpServerPorts;
-		SmallTable<ConnectionTuple> permittedTCPEndpoints;
-		SmallTable<ConnectionTuple> permittedUDPEndpoints;
-		FlagLockPriorityInherited   permittedEndpointsLock;
+		using ConnectionTable =
+		  SmallTable<ConnectionTuple, offsetof(ConnectionTuple, state)>;
+
+		SmallTable<uint16_t>      tcpServerPorts;
+		ConnectionTable           permittedTCPEndpoints;
+		ConnectionTable           permittedUDPEndpoints;
+		FlagLockPriorityInherited permittedEndpointsLock;
 
 		using GuardedTable =
 		  std::pair<LockGuard<decltype(permittedEndpointsLock)>,
@@ -546,6 +566,17 @@ namespace
 			                    protocol == IPProtocolNumber::TCP
 			                      ? permittedTCPEndpoints
 			                      : permittedUDPEndpoints};
+		}
+
+		/**
+		 * Find a hole by endpoint without comparing its state.
+		 *
+		 * Returns the matching hole, or `nullptr` if none is found.
+		 */
+		ConnectionTuple *find_endpoint(ConnectionTable       &table,
+		                               const ConnectionTuple &key)
+		{
+			return table.find(key);
 		}
 
 		public:
@@ -574,8 +605,85 @@ namespace
 			// auto [g, table] = permitted_endpoints(protocol);
 			auto guardedTable = permitted_endpoints(protocol);
 			auto &[g, table]  = guardedTable;
-			ConnectionTuple tuple{endpoint, localPort, remotePort};
+			ConnectionTuple tuple{
+			  endpoint, localPort, remotePort, TCPFirewallState::InUse};
 			return table.remove(tuple);
+		}
+
+		/**
+		 * Change a TCP hole from `InUse` to `InTermination`.
+		 *
+		 * Returns:
+		 *
+		 *  - 0 on success.
+		 *  - `-ENOENT` if no in-use hole matches.
+		 */
+		int mark_tcp_endpoint_in_termination(Address  remoteAddress,
+		                                     uint16_t localPort,
+		                                     uint16_t remotePort)
+		{
+			LockGuard       g{permittedEndpointsLock};
+			ConnectionTuple key{
+			  remoteAddress, localPort, remotePort, TCPFirewallState::InUse};
+			if (ConnectionTuple *tuple =
+			      find_endpoint(permittedTCPEndpoints, key);
+			    (tuple != nullptr) && (tuple->state == TCPFirewallState::InUse))
+			{
+				// The final packet still needs this hole.
+				tuple->state = TCPFirewallState::InTermination;
+				return 0;
+			}
+			return -ENOENT;
+		}
+
+		/**
+		 * Change a TCP hole from `InTermination` to `CanBeRemoved`.
+		 *
+		 * Returns:
+		 *
+		 *  - 0 on success.
+		 *  - `-ENOENT` if no closing hole matches.
+		 */
+		int mark_tcp_endpoint_can_be_removed(Address  remoteAddress,
+		                                     uint16_t localPort,
+		                                     uint16_t remotePort)
+		{
+			LockGuard       g{permittedEndpointsLock};
+			ConnectionTuple key{remoteAddress,
+			                    localPort,
+			                    remotePort,
+			                    TCPFirewallState::InTermination};
+			if (ConnectionTuple *tuple =
+			      find_endpoint(permittedTCPEndpoints, key);
+			    (tuple != nullptr) &&
+			    (tuple->state == TCPFirewallState::InTermination))
+			{
+				// The final packet passed the filter.
+				tuple->state = TCPFirewallState::CanBeRemoved;
+				return 0;
+			}
+			return -ENOENT;
+		}
+
+		/**
+		 * Get a TCP hole's state without changing it.
+		 *
+		 * Returns the state, or `TCPFirewallState::NotFound` if no hole
+		 * matches.
+		 */
+		TCPFirewallState tcp_endpoint_state(Address  remoteAddress,
+		                                    uint16_t localPort,
+		                                    uint16_t remotePort)
+		{
+			LockGuard       g{permittedEndpointsLock};
+			ConnectionTuple key{
+			  remoteAddress, localPort, remotePort, TCPFirewallState::InUse};
+			if (ConnectionTuple *tuple =
+			      find_endpoint(permittedTCPEndpoints, key))
+			{
+				return tuple->state;
+			}
+			return TCPFirewallState::NotFound;
 		}
 
 		void add_server_port(uint16_t localPort)
@@ -607,8 +715,12 @@ namespace
 			// auto [g, table] = permitted_endpoints(protocol);
 			auto guardedTable = permitted_endpoints(protocol);
 			auto &[g, table]  = guardedTable;
-			ConnectionTuple tuple{remoteAddress, localPort, remotePort};
-			table.insert(tuple);
+			ConnectionTuple tuple{
+			  remoteAddress, localPort, remotePort, TCPFirewallState::InUse};
+			if (!table.contains(tuple))
+			{
+				table.insert(tuple);
+			}
 		}
 
 		void remove_endpoint(IPProtocolNumber protocol, uint16_t localPort)
@@ -643,7 +755,8 @@ namespace
 			// auto [g, table] = permitted_endpoints(protocol);
 			auto guardedTable = permitted_endpoints(protocol);
 			auto &[g, table]  = guardedTable;
-			ConnectionTuple tuple{endpoint, localPort, remotePort};
+			ConnectionTuple tuple{
+			  endpoint, localPort, remotePort, TCPFirewallState::InUse};
 			return table.contains(tuple);
 		}
 	};
@@ -881,6 +994,23 @@ namespace
 				else
 				{
 					Debug::log("Permitting outbound IPv4 packet");
+
+					const auto *ipv4Header =
+					  reinterpret_cast<const IPv4Header *>(
+					    data + sizeof(EthernetHeader));
+					if (ipv4Header->protocol == IPProtocolNumber::TCP)
+					{
+						const auto *tcpHeader =
+						  reinterpret_cast<const TCPUDPCommonPrefix *>(
+						    reinterpret_cast<const uint8_t *>(ipv4Header) +
+						    ipv4Header->body_offset());
+						// The packet passed; its hole may now be removed.
+						(void)EndpointsTable<uint32_t>::instance()
+						  .mark_tcp_endpoint_can_be_removed(
+						    ipv4Header->destinationAddress,
+						    tcpHeader->sourcePort,
+						    tcpHeader->destinationPort);
+					}
 				}
 				return ret;
 			}
@@ -1065,6 +1195,22 @@ void firewall_add_tcpipv4_endpoint(uint32_t remoteAddress,
 {
 	EndpointsTable<uint32_t>::instance().add_endpoint(
 	  IPProtocolNumber::TCP, remoteAddress, localPort, remotePort);
+}
+
+int firewall_mark_tcpipv4_endpoint_in_termination(uint32_t remoteAddress,
+                                                  uint16_t localPort,
+                                                  uint16_t remotePort)
+{
+	return EndpointsTable<uint32_t>::instance()
+	  .mark_tcp_endpoint_in_termination(remoteAddress, localPort, remotePort);
+}
+
+TCPFirewallState firewall_get_tcpipv4_endpoint_state(uint32_t remoteAddress,
+                                                     uint16_t localPort,
+                                                     uint16_t remotePort)
+{
+	return EndpointsTable<uint32_t>::instance().tcp_endpoint_state(
+	  remoteAddress, localPort, remotePort);
 }
 
 void firewall_add_udpipv4_endpoint(uint32_t remoteAddress,

--- a/lib/firewall/firewall.cc
+++ b/lib/firewall/firewall.cc
@@ -1205,12 +1205,13 @@ int firewall_mark_tcpipv4_endpoint_in_termination(uint32_t remoteAddress,
 	  .mark_tcp_endpoint_in_termination(remoteAddress, localPort, remotePort);
 }
 
-TCPFirewallState firewall_get_tcpipv4_endpoint_state(uint32_t remoteAddress,
-                                                     uint16_t localPort,
-                                                     uint16_t remotePort)
+int firewall_get_tcpipv4_endpoint_state(uint32_t remoteAddress,
+                                        uint16_t localPort,
+                                        uint16_t remotePort)
 {
-	return EndpointsTable<uint32_t>::instance().tcp_endpoint_state(
-	  remoteAddress, localPort, remotePort);
+	return static_cast<int>(
+	  EndpointsTable<uint32_t>::instance().tcp_endpoint_state(
+	    remoteAddress, localPort, remotePort));
 }
 
 void firewall_add_udpipv4_endpoint(uint32_t remoteAddress,

--- a/lib/firewall/firewall.hh
+++ b/lib/firewall/firewall.hh
@@ -114,18 +114,17 @@ void __cheri_compartment("Firewall")
 
 /**
  * State of an IPv4 TCP firewall hole during close.
- *
- *  - `InUse`: The connection is open and packets may pass.
- *  - `InTermination`: The final packet has not passed egress yet.
- *  - `CanBeRemoved`: Egress passed the final packet; the hole may be removed.
- *  - `NotFound`: No hole matches the address and ports.
  */
 enum class TCPFirewallState : uint8_t
 {
-	InUse         = 0,
+	/// The socket is active and packets may pass through this hole.
+	InUse = 0,
+	/// The socket is closing and its final ACK has not passed egress.
 	InTermination = 1,
-	CanBeRemoved  = 2,
-	NotFound      = 3,
+	/// The final ACK passed egress and the hole may be removed.
+	CanBeRemoved = 2,
+	/// No hole matches the remote address and local and remote ports.
+	NotFound = 3,
 };
 
 /**

--- a/lib/firewall/firewall.hh
+++ b/lib/firewall/firewall.hh
@@ -120,7 +120,7 @@ void __cheri_compartment("Firewall")
  *  - `CanBeRemoved`: Egress passed the final packet; the hole may be removed.
  *  - `NotFound`: No hole matches the address and ports.
  */
-enum class TCPFirewallState : uint32_t
+enum class TCPFirewallState : uint8_t
 {
 	InUse         = 0,
 	InTermination = 1,
@@ -145,9 +145,14 @@ int __cheri_compartment("Firewall")
 /**
  * Get a TCP hole's state without changing it.
  *
- * Returns the state, or `TCPFirewallState::NotFound` if no hole matches.
+ * Returns:
+ *
+ *  - A `TCPFirewallState` value on success.
+ *  - `-ENOTENOUGHSTACK` if there is not enough stack to call the compartment.
+ *  - `-ENOTENOUGHTRUSTEDSTACK` if there is not enough trusted stack.
+ *  - `-ECOMPARTMENTFAIL` if the firewall compartment fails.
  */
-TCPFirewallState __cheri_compartment("Firewall")
+int __cheri_compartment("Firewall")
   firewall_get_tcpipv4_endpoint_state(uint32_t remoteAddress,
                                       uint16_t localPort,
                                       uint16_t remotePort);

--- a/lib/firewall/firewall.hh
+++ b/lib/firewall/firewall.hh
@@ -113,6 +113,46 @@ void __cheri_compartment("Firewall")
                                 uint16_t remotePort);
 
 /**
+ * State of an IPv4 TCP firewall hole during close.
+ *
+ *  - `InUse`: The connection is open and packets may pass.
+ *  - `InTermination`: The final packet has not passed egress yet.
+ *  - `CanBeRemoved`: Egress passed the final packet; the hole may be removed.
+ *  - `NotFound`: No hole matches the address and ports.
+ */
+enum class TCPFirewallState : uint32_t
+{
+	InUse         = 0,
+	InTermination = 1,
+	CanBeRemoved  = 2,
+	NotFound      = 3,
+};
+
+/**
+ * Change a TCP hole from `InUse` to `InTermination`, keeping it open for the
+ * final egress packet.
+ *
+ * Returns:
+ *
+ *  - 0 on success.
+ *  - `-ENOENT` if no in-use hole matches.
+ */
+int __cheri_compartment("Firewall")
+  firewall_mark_tcpipv4_endpoint_in_termination(uint32_t remoteAddress,
+                                                uint16_t localPort,
+                                                uint16_t remotePort);
+
+/**
+ * Get a TCP hole's state without changing it.
+ *
+ * Returns the state, or `TCPFirewallState::NotFound` if no hole matches.
+ */
+TCPFirewallState __cheri_compartment("Firewall")
+  firewall_get_tcpipv4_endpoint_state(uint32_t remoteAddress,
+                                      uint16_t localPort,
+                                      uint16_t remotePort);
+
+/**
  * Open a hole in the firewall for UDP packets to and from the given endpoint.
  * This permits inbound packets to, and outbound packets from, the specified
  * local port, if the remote endpoint is the given remote address and port.

--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -415,6 +415,9 @@ namespace
  * an attempted three-way-handshake failed. We can use it to tell the firewall
  * to remove the hole.
  *
+ * For an active close, FreeRTOS also calls this before sending the final ACK.
+ * The firewall hole must stay open until that ACK passes its egress filter.
+ *
  * Note that this may or may not be called if *we* close the socket through
  * `FreeRTOS_closesocket`: if the remote peer does not complete the termination
  * handshake or if our timeout runs out, the connection may be left dangling,
@@ -425,8 +428,8 @@ static void on_tcp_connect(Socket_t socket, BaseType_t isConnected)
 	if (!isConnected)
 	{
 		/**
-		 * A TCP connection was closed. Close the corresponding
-		 * firewall hole.
+		 * A TCP connection was closed. Close its firewall hole, or hold
+		 * it open for the final ACK.
 		 *
 		 * Note that this is called from the TCP/IP thread, i.e., it
 		 * cannot possibly race with a free of the `socket`, even if
@@ -447,8 +450,29 @@ static void on_tcp_connect(Socket_t socket, BaseType_t isConnected)
 		}
 		else
 		{
-			firewall_remove_tcpipv4_remote_endpoint(
-			  address.sin_address.ulIP_IPv4, localPort, address.sin_port);
+			const auto &tcp = socket->u.xTCP;
+			/*
+			 * Check whether we are the termination
+			 * initiator and ready to send the final ack.
+			 */
+			if ((tcp.eTCPState == eCLOSE_WAIT) && !tcp.bits.bFinAccepted &&
+			    tcp.bits.bFinSent && tcp.bits.bFinRecv && tcp.bits.bFinAcked &&
+			    !tcp.bits.bFinLast)
+			{
+				// Wait for egress to mark the hole safe to remove.
+				if (firewall_mark_tcpipv4_endpoint_in_termination(
+				      address.sin_address.ulIP_IPv4,
+				      localPort,
+				      address.sin_port) != 0)
+				{
+					Debug::log("Failed to mark the firewall hole as closing");
+				}
+			}
+			else
+			{
+				firewall_remove_tcpipv4_remote_endpoint(
+				  address.sin_address.ulIP_IPv4, localPort, address.sin_port);
+			}
 		}
 	}
 }
@@ -880,8 +904,15 @@ int network_socket_close(Timeout            *t,
 						  {
 							  Timeout sleep{1};
 							  thread_sleep(&sleep);
+							  // Count this sleep in the caller's timeout.
+							  t->elapse(sleep.elapsed);
 						  }
 					  } while (!terminated && t->may_block());
+
+					  if (!terminated)
+					  {
+						  return -ETIMEDOUT;
+					  }
 				  }
 
 				  auto localPort = htons(rawSocket->usLocalPort);
@@ -947,6 +978,38 @@ int network_socket_close(Timeout            *t,
 						  }
 						  else
 						  {
+							  // Get the state of the endpoint associated
+							  // with this socket.
+							  auto firewallState =
+							    firewall_get_tcpipv4_endpoint_state(
+							      address.sin_address.ulIP_IPv4,
+							      localPort,
+							      address.sin_port);
+
+							  // Wait until egress marks the hole safe to
+							  // remove.
+							  while ((firewallState !=
+							          TCPFirewallState::CanBeRemoved) &&
+							         t->may_block())
+							  {
+								  Timeout sleep{1};
+								  thread_sleep(&sleep);
+								  t->elapse(sleep.elapsed);
+								  firewallState =
+								    firewall_get_tcpipv4_endpoint_state(
+								      address.sin_address.ulIP_IPv4,
+								      localPort,
+								      address.sin_port);
+							  }
+
+							  if (firewallState !=
+							      TCPFirewallState::CanBeRemoved)
+							  {
+								  // Keep the socket and hole so the caller can
+								  // retry.
+								  return -ETIMEDOUT;
+							  }
+
 							  firewall_remove_tcpipv4_remote_endpoint(
 							    address.sin_address.ulIP_IPv4,
 							    localPort,

--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -988,8 +988,10 @@ int network_socket_close(Timeout            *t,
 
 							  // Wait until egress marks the hole safe to
 							  // remove.
-							  while ((firewallState !=
-							          TCPFirewallState::CanBeRemoved) &&
+							  while ((firewallState >= 0) &&
+							         (firewallState !=
+							          static_cast<int>(
+							            TCPFirewallState::CanBeRemoved)) &&
 							         t->may_block())
 							  {
 								  Timeout sleep{1};
@@ -1002,8 +1004,14 @@ int network_socket_close(Timeout            *t,
 								      address.sin_port);
 							  }
 
+							  if (firewallState < 0)
+							  {
+								  return firewallState;
+							  }
+
 							  if (firewallState !=
-							      TCPFirewallState::CanBeRemoved)
+							      static_cast<int>(
+							        TCPFirewallState::CanBeRemoved))
 							  {
 								  // Keep the socket and hole so the caller can
 								  // retry.


### PR DESCRIPTION
During an active TCP close, FreeRTOS calls `on_tcp_connect` before sending the final ACK. At that point, the callback removed the TCP firewall hole, so the firewall dropped the ACK and the peer could not finish closing. Waiting for the TCP state change is not enough because the state changes before the ACK passes through egress.

Keep the firewall hole open until the final ACK passes through egress. `on_tcp_connect` marks the hole as closing, egress marks it as safe to remove, and `network_socket_close()` removes it afterward.

Key changes:
- Add a state field to each TCP firewall hole: `InUse` for an open connection, `InTermination` while waiting for the final ACK, and `CanBeRemoved` after that ACK passes egress. `NotFound` means that no matching hole exists.
- Change the `SmallTableBase` helpers to compare only each table's key fields. The endpoint key remains the address and ports, so existing helper calls keep their old behavior and ignore the new state field. Lookup remains `O(log n)`; only the close helpers inspect the state.
- Change the hole from `InUse` to `InTermination` in `on_tcp_connect`.
- Change it from `InTermination` to `CanBeRemoved` after the next matching packet passes egress.
- Make `network_socket_close()` wait for `CanBeRemoved` before removing the hole. A successful return guarantees that the hole was removed.

Note:
The polling [here](https://github.com/CHERIoT-Platform/network-stack/blob/58425e6a1c65c4357b037aa817ba492e7a8fa70b/lib/tcpip/network_wrapper.cc#L865) can be removed for ipv4 path, but I keep it here for ipv6. Since the firewall endpoint delayed removal and polling for firewall state logics are currently only applied to ipv4 path. The polling here still make sure we are at a safe point to free the socket, but it is not a signal of we can safely remove the firewall endpoint.