### PR TITLE
Add missing check_timeout_pointer in network_socket_connect_tcp_internal

### DIFF
--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -753,6 +753,10 @@ int network_socket_connect_tcp_internal(Timeout       *timeout,
                                         NetworkAddress address,
                                         short          port)
 {
+	if (!check_timeout_pointer(timeout))
+	{
+		return -EINVAL;
+	}
 	return with_sealed_socket(
 	  [&](SealedSocket *socket) {
 		  bool                     isIPv6 = socket->socket->bits.bIsIPv6;


### PR DESCRIPTION
This was detected by the CheriotHeapChecker static analysis.
