### PR TITLE
TCPIP: add multiwaiter support for TCP connect

### DIFF
--- a/include/NetAPI.h
+++ b/include/NetAPI.h
@@ -309,9 +309,10 @@ Socket __cheri_compartment("TCPIP")
  * Return the event source associated with a socket.
  *
  * The returned capability is read-only and bounded to four bytes.
- * For a connected TCP socket, the first non-empty send initializes
- * `SocketTCPSendEvent`, which then counts bytes that a zero-timeout send may
- * add to the transmit stream.
+ * For a TCP socket, the futex `SocketTCPSendEvent` initially reports
+ * the configured maximum txStream capacity before the buffer is allocated.
+ * This is to prevent the user thread from sleeping on the multi-waiter
+ * forever before the first `network_socket_send()` is called.
  */
 uint32_t *__cheri_compartment("TCPIP")
   network_socket_get_event_source(Socket sealedSocket, SocketEventType type);

--- a/include/NetAPI.h
+++ b/include/NetAPI.h
@@ -40,8 +40,12 @@ struct NetworkAddress
  */
 enum SocketEventType : uint8_t
 {
-	SocketAcceptEvent = 0, // Triggered when a new TCP connection is accepted on
-	                       // a listening socket
+	/// Triggered when a new TCP connection
+	/// is accepted on a listening socket.
+	/// The value of the futex corresponding to
+	/// SocketAcceptEvent, means the number of
+	/// pending connections.
+	SocketAcceptEvent = 0,
 	// SocketReceiveEvent = 1, // Triggered when data is received on a socket
 	// SocketSendEvent = 2     // Triggered when a socket has space available
 	// for sending

--- a/include/NetAPI.h
+++ b/include/NetAPI.h
@@ -35,6 +35,25 @@ struct NetworkAddress
 };
 
 /**
+ * Enumeration that defines futex types. Each value corresponds
+ * to an index in the socket's futex array.
+ */
+enum SocketEventType : uint8_t
+{
+	SocketAcceptEvent = 0, // Triggered when a new TCP connection is accepted on
+	                       // a listening socket
+	// SocketReceiveEvent = 1, // Triggered when data is received on a socket
+	// SocketSendEvent = 2     // Triggered when a socket has space available
+	// for sending
+};
+
+/// Number of distinct socket event futex types.
+static constexpr size_t NumFutexTypes = SocketEventType::SocketAcceptEvent + 1;
+/// Sentinel value stored in a socket event futex after the socket has been
+/// torn down.
+static constexpr uint32_t SocketNotAvailable = -1;
+
+/**
  * Enumeration defining the connection type.
  */
 enum ConnectionType : uint8_t
@@ -268,6 +287,14 @@ Socket __cheri_compartment("TCPIP")
   network_socket_udp(Timeout            *timeout,
                      AllocatorCapability mallocCapability,
                      bool                isIPv6);
+
+/**
+ * Return the event source associated with a socket.
+ *
+ * The returned capability is read-only and bounded to four bytes.
+ */
+uint32_t *__cheri_compartment("TCPIP")
+  network_socket_get_event_source(Socket sealedSocket, SocketEventType type);
 
 /**
  * Authorise a UDP socket to send packets to a specific host.  This opens a

--- a/include/NetAPI.h
+++ b/include/NetAPI.h
@@ -51,7 +51,7 @@ enum SocketEventType : uint8_t
 static constexpr size_t NumFutexTypes = SocketEventType::SocketAcceptEvent + 1;
 /// Sentinel value stored in a socket event futex after the socket has been
 /// torn down.
-static constexpr uint32_t SocketNotAvailable = -1;
+static constexpr int32_t SocketNotAvailable = INT32_MIN;
 
 /**
  * Enumeration defining the connection type.

--- a/include/NetAPI.h
+++ b/include/NetAPI.h
@@ -57,14 +57,21 @@ enum SocketEventType : uint8_t
 	/// whenever any space is available; it may send only part of the requested
 	/// data.
 	SocketTCPSendEvent = 1,
+	/// The connection state of an outgoing TCP socket.
+	/// Zero means connecting, one means connected. The futex
+	/// never changes from 1 back to 0. Since the connect futex is a state, not
+	/// a consumable event. Resetting it to zero would incorrectly mean that
+	/// this socket it not connected.
+	SocketTCPConnectEvent = 2,
 	// Triggered when data is received on a socket
-	// SocketReceiveEvent = 2,
+	// SocketReceiveEvent = 3,
 };
 
 /// Number of distinct socket event futex types.
-static constexpr size_t NumFutexTypes = SocketEventType::SocketTCPSendEvent + 1;
-/// Sentinel value stored in the TCP send event futex when the wrapper still
-/// exists but the TCP connection can no longer send.
+static constexpr size_t NumFutexTypes =
+  SocketEventType::SocketTCPConnectEvent + 1;
+/// Sentinel value stored in a TCP event futex when the wrapper still exists
+/// but the TCP connection has closed.
 static constexpr int32_t SocketConnectionClosed = INT32_MIN + 1;
 /// Sentinel value stored in a socket event futex after the socket has been
 /// torn down.
@@ -225,10 +232,11 @@ typedef CHERI_SEALED(struct SealedSocket *) Socket;
 void __cheri_compartment("TCPIP") network_start(void);
 
 /**
- * Create a connected TCP socket.
+ * Create a TCP socket and connect it to an authorised host.
  *
  * This function will block until the connection is established or the timeout
- * is reached.
+ * is reached. With a zero timeout, it starts the connection and returns without
+ * waiting for it to complete.
  *
  * The `mallocCapability` argument is used to allocate memory for the socket
  * and must have sufficient quota remaining for the socket.
@@ -236,8 +244,14 @@ void __cheri_compartment("TCPIP") network_start(void);
  * The `hostCapability` argument is a capability authorising the connection to
  * a specific host.
  *
- * This returns a valid sealed capability to a socket on success, or an
- * untagged value on failure.
+ * The return value is:
+ *
+ *  - A valid sealed socket capability if the connection succeeds or a
+ *    zero-timeout call starts the connection.
+ *  - An untagged value if the operation fails or a blocking call reaches its
+ *    timeout.
+ *
+ * The caller must close any valid socket returned by this function.
  */
 Socket __cheri_compartment("NetAPI")
   network_socket_connect_tcp(Timeout             *timeout,

--- a/include/NetAPI.h
+++ b/include/NetAPI.h
@@ -46,13 +46,26 @@ enum SocketEventType : uint8_t
 	/// SocketAcceptEvent, means the number of
 	/// pending connections.
 	SocketAcceptEvent = 0,
-	// SocketReceiveEvent = 1, // Triggered when data is received on a socket
-	// SocketSendEvent = 2     // Triggered when a socket has space available
-	// for sending
+	/// Triggered when a socket has space available
+	/// for sending bytes.
+	/// The value of the futex corresponding to
+	/// SocketTCPSendEvent, means the number of free
+	/// bytes available in the txStream buffer of
+	/// the socket.
+	/// After multiwaiter_wait() returns, do not wait for this value to reach
+	/// the full size of the pending send. Call network_socket_send() again
+	/// whenever any space is available; it may send only part of the requested
+	/// data.
+	SocketTCPSendEvent = 1,
+	// Triggered when data is received on a socket
+	// SocketReceiveEvent = 2,
 };
 
 /// Number of distinct socket event futex types.
-static constexpr size_t NumFutexTypes = SocketEventType::SocketAcceptEvent + 1;
+static constexpr size_t NumFutexTypes = SocketEventType::SocketTCPSendEvent + 1;
+/// Sentinel value stored in the TCP send event futex when the wrapper still
+/// exists but the TCP connection can no longer send.
+static constexpr int32_t SocketConnectionClosed = INT32_MIN + 1;
 /// Sentinel value stored in a socket event futex after the socket has been
 /// torn down.
 static constexpr int32_t SocketNotAvailable = INT32_MIN;
@@ -296,6 +309,9 @@ Socket __cheri_compartment("TCPIP")
  * Return the event source associated with a socket.
  *
  * The returned capability is read-only and bounded to four bytes.
+ * For a connected TCP socket, the first non-empty send initializes
+ * `SocketTCPSendEvent`, which then counts bytes that a zero-timeout send may
+ * add to the transmit stream.
  */
 uint32_t *__cheri_compartment("TCPIP")
   network_socket_get_event_source(Socket sealedSocket, SocketEventType type);

--- a/lib/netapi/NetAPI.cc
+++ b/lib/netapi/NetAPI.cc
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <debug.hh>
 #include <endianness.hh>
+#include <errno.h>
 #include <token.h>
 
 constexpr bool DebugNetAPI =
@@ -116,8 +117,9 @@ Socket network_socket_connect_tcp(Timeout             *timeout,
 		  address.ipv4, kind.localPort, ntohs(host->port));
 	}
 
-	if (network_socket_connect_tcp_internal(
-	      timeout, sealedSocket, address, host->port) != 0)
+	int connectResult = network_socket_connect_tcp_internal(
+	  timeout, sealedSocket, address, host->port);
+	if ((connectResult != 0) && (connectResult != -EINPROGRESS))
 	{
 		Timeout t{UnlimitedTimeout};
 		// We pass an unlimited timeout, so this cannot fail in any

--- a/lib/tcpip/network-internal.h
+++ b/lib/tcpip/network-internal.h
@@ -45,6 +45,8 @@ Socket __cheri_compartment("TCPIP")
 
 /**
  * Connect a TCP socket to the given address.
+ *
+ * Returns `-EINPROGRESS` if a zero timeout starts the connection.
  */
 int __cheri_compartment("TCPIP")
   network_socket_connect_tcp_internal(Timeout       *timeout,

--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -715,6 +715,13 @@ Socket network_socket_accept_tcp(Timeout            *timeout,
 		  }
 
 		  socketWrapper->socketEpoch = currentSocketEpoch.load();
+		  /*
+		   * For the newly allocated child socket, initialize the futexes.
+		   */
+		  for (auto &eventState : socketWrapper->eventFutexState)
+		  {
+			  eventState.store(0);
+		  }
 
 		  struct freertos_sockaddr addressTmp;
 		  uint32_t                 addressLength = sizeof(addressTmp);
@@ -798,6 +805,7 @@ Socket network_socket_accept_tcp(Timeout            *timeout,
 			  token_obj_destroy(mallocCapability, socket_key(), sealedSocket);
 			  return -EINVAL;
 		  }
+		  xSocketSetSocketID(rawSocket, socketWrapper);
 
 		  // Set `address`.
 		  if ((heap_claim_ephemeral(timeout, address) < 0) ||

--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -425,6 +425,12 @@ int SealedSocket::signal_event_futex(SocketEventType type)
 	uint32_t current = futex.load();
 	while (current != SocketNotAvailable)
 	{
+		/*
+		 * If the futex's current value equals current,
+		 * store current + 1 and return true. Otherwise
+		 * write the actual current value into current
+		 * (by reference) and return false.
+		 */
 		if (futex.compare_exchange_strong(current, current + 1))
 		{
 			futex.notify_all();
@@ -435,10 +441,6 @@ int SealedSocket::signal_event_futex(SocketEventType type)
 	return -EINVAL;
 }
 
-/**
- * The caller must hold socketLock, which prevents the SealedSocket from being
- * deallocated while this method accesses the futex.
- */
 int SealedSocket::consume_event_futex(SocketEventType type)
 {
 	auto    &futex   = eventFutexState[type];

--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -415,6 +415,24 @@ namespace
 
 } // namespace
 
+void SealedSocket::initialize_event_futexes()
+{
+	for (auto &eventState : eventFutexState)
+	{
+		eventState.store(0);
+	}
+
+	if (socket->ucProtocol == FREERTOS_IPPROTO_TCP)
+	{
+		/*
+		 * FreeRTOS creates txStream lazily.  Lie about its current space and
+		 * use its maximum size now: otherwise a caller that waits on this futex
+		 * before its first send() will block forever.
+		 */
+		eventFutexState[SocketTCPSendEvent].store(FreeRTOS_tx_space(socket));
+	}
+}
+
 int SealedSocket::signal_event_futex(SocketEventType type, int32_t count)
 {
 	auto &futex = eventFutexState[type];
@@ -608,12 +626,6 @@ Socket network_socket_create_and_bind(Timeout            *timeout,
 
 		  // Set the socket epoch
 		  socketWrapper->socketEpoch = currentSocketEpoch.load();
-		  // Multi-waiter: initialize the futexes.
-		  for (auto &eventState : socketWrapper->eventFutexState)
-		  {
-			  eventState.store(0);
-		  }
-
 		  const auto Family = isIPv6 ? FREERTOS_AF_INET6 : FREERTOS_AF_INET;
 		  Socket_t   socket =
 		    FreeRTOS_socket(Family,
@@ -637,6 +649,7 @@ Socket network_socket_create_and_bind(Timeout            *timeout,
 		   * socket wrapper from the FreeRTOS socket in the callbacks.
 		   */
 		  socketWrapper->socket = socket;
+		  socketWrapper->initialize_event_futexes();
 		  xSocketSetSocketID(socket, socketWrapper);
 
 		  // Claim the socket so that it counts towards the caller's quota.  The
@@ -780,14 +793,6 @@ Socket network_socket_accept_tcp(Timeout            *timeout,
 		  }
 
 		  socketWrapper->socketEpoch = currentSocketEpoch.load();
-		  /*
-		   * For the newly allocated child socket, initialize the futexes.
-		   */
-		  for (auto &eventState : socketWrapper->eventFutexState)
-		  {
-			  eventState.store(0);
-		  }
-
 		  struct freertos_sockaddr addressTmp;
 		  uint32_t                 addressLength = sizeof(addressTmp);
 		  FreeRTOS_Socket_t       *rawSocket     = nullptr;
@@ -836,6 +841,7 @@ Socket network_socket_accept_tcp(Timeout            *timeout,
 			  return futexConsumeResult;
 		  }
 		  socketWrapper->socket = rawSocket;
+		  socketWrapper->initialize_event_futexes();
 
 		  // Claim the socket so that it counts towards the caller's quota.  The
 		  // network stack also keeps a claim to it.  We will drop this claim on
@@ -1486,24 +1492,25 @@ ssize_t network_socket_send(Timeout *timeout,
 		  {
 			  return -EPERM;
 		  }
-		  // Create the txStream and initialize send futex on the
-		  // first non-zero send.
+		  // Create txStream on the first non-zero send and replace the
+		  // fake place holder value with its exact available space.
 		  if ((length != 0) && (socket->socket->u.xTCP.txStream == nullptr))
 		  {
+			  int32_t advertisedSpace = FreeRTOS_tx_space(socket->socket);
 			  if (FreeRTOS_get_tx_base(socket->socket) == nullptr)
 			  {
 				  // Allocation failed.
 				  return -ENOMEM;
 			  }
-			  // Store current available bytes to initialize the futex.
+			  // Reconcile the advertised capacity with the newly allocated
+			  // stream's exact usable space.
 			  auto &sendFutex =
 			    socket->eventFutexState[SocketEventType::SocketTCPSendEvent];
-			  int32_t uninitialized = 0;
 			  // The reason why we use compare_exchange_* here is that
 			  // if the socket is disconnected, a plain .store() would
 			  // overwrite SocketConnectionClosed.
 			  sendFutex.compare_exchange_strong(
-			    uninitialized, FreeRTOS_tx_space(socket->socket));
+			    advertisedSpace, FreeRTOS_tx_space(socket->socket));
 		  }
 		  Debug::log("Sending {}-byte TCP packet from {}", length, buffer);
 		  int ret = with_freertos_timeout(

--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -422,7 +422,7 @@ int SealedSocket::signal_event_futex(SocketEventType type)
 	{
 		return -EINVAL;
 	}
-	uint32_t current = futex.load();
+	int32_t current = futex.load();
 	while (current != SocketNotAvailable)
 	{
 		/*
@@ -443,9 +443,9 @@ int SealedSocket::signal_event_futex(SocketEventType type)
 
 int SealedSocket::consume_event_futex(SocketEventType type)
 {
-	auto    &futex   = eventFutexState[type];
-	uint32_t current = futex.load();
-	while (current != SocketNotAvailable && current != 0)
+	auto   &futex   = eventFutexState[type];
+	int32_t current = futex.load();
+	while (current != SocketNotAvailable)
 	{
 		if (futex.compare_exchange_strong(current, current - 1))
 		{
@@ -453,7 +453,7 @@ int SealedSocket::consume_event_futex(SocketEventType type)
 		}
 	}
 
-	return (current == SocketNotAvailable) ? -EINVAL : 0;
+	return -EINVAL;
 }
 
 /**
@@ -933,18 +933,17 @@ uint32_t *network_socket_get_event_source(Socket          sealedSocket,
 	{
 		with_sealed_socket(
 		  [&](SealedSocket *socket) {
-			  auto *futex =
-			    reinterpret_cast<uint32_t *>(&socket->eventFutexState[type]);
+			  auto *futex = &socket->eventFutexState[type];
 
-			  Capability readyOnlyEventSource{futex};
-			  // Restrict the capability to read-only so the futex can only be
-			  // modified through the callback, not by the caller of this
-			  // helper.
-			  readyOnlyEventSource.bounds() = sizeof(uint32_t);
-			  readyOnlyEventSource.permissions() &=
+			  Capability readOnlyEventSource{futex};
+			  // Expose the futex as read-only. The caller may observe its raw
+			  // 32-bit representation but may modify it only through the
+			  // socket callbacks.
+			  readOnlyEventSource.bounds() = sizeof(*futex);
+			  readOnlyEventSource.permissions() &=
 			    {Permission::Load, Permission::Global};
 
-			  result = readyOnlyEventSource.get();
+			  result = reinterpret_cast<uint32_t *>(readOnlyEventSource.get());
 			  return 0;
 		  },
 		  sealedSocket);

--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -412,7 +412,47 @@ namespace
 
 		return ret;
 	}
+
 } // namespace
+
+int SealedSocket::signal_event_futex(SocketEventType type)
+{
+	auto &futex = eventFutexState[type];
+	if (heap_claim_ephemeral(TimeoutWaitForever, &futex) != 0)
+	{
+		return -EINVAL;
+	}
+	uint32_t current = futex.load();
+	while (current != SocketNotAvailable)
+	{
+		if (futex.compare_exchange_strong(current, current + 1))
+		{
+			futex.notify_all();
+			return 0;
+		}
+	}
+
+	return -EINVAL;
+}
+
+/**
+ * The caller must hold socketLock, which prevents the SealedSocket from being
+ * deallocated while this method accesses the futex.
+ */
+int SealedSocket::consume_event_futex(SocketEventType type)
+{
+	auto    &futex   = eventFutexState[type];
+	uint32_t current = futex.load();
+	while (current != SocketNotAvailable && current != 0)
+	{
+		if (futex.compare_exchange_strong(current, current - 1))
+		{
+			return 0;
+		}
+	}
+
+	return (current == SocketNotAvailable) ? -EINVAL : 0;
+}
 
 /**
  * Callback called by FreeRTOS+TCP when a TCP connection is created or
@@ -468,6 +508,24 @@ static void on_tcp_connect(Socket_t socket, BaseType_t isConnected)
 			  address.sin_address.ulIP_IPv4, localPort, address.sin_port);
 		}
 	}
+	else
+	{
+		// Update eventFutexState in the listening socket and wake up the
+		// threads sleeping on the corresponding futex.
+		// Use the FreeRTOS getter to get the wrapper capability we stored in
+		// it.
+		auto *wrapper =
+		  static_cast<SealedSocket *>(pvSocketGetSocketID(socket));
+		if (wrapper != nullptr)
+		{
+			/*
+			 * Ignore the return value. If the socket has been invalidated,
+			 * the subsequent accept call will detect that it is unavailable.
+			 */
+			wrapper->signal_event_futex(SocketEventType::SocketAcceptEvent);
+		}
+		return;
+	}
 }
 F_TCP_UDP_Handler_t onTCPConnectCallback = {on_tcp_connect};
 
@@ -495,6 +553,11 @@ Socket network_socket_create_and_bind(Timeout            *timeout,
 
 		  // Set the socket epoch
 		  socketWrapper->socketEpoch = currentSocketEpoch.load();
+		  // Multi-waiter: initialize the futexes.
+		  for (auto &eventState : socketWrapper->eventFutexState)
+		  {
+			  eventState.store(0);
+		  }
 
 		  const auto Family = isIPv6 ? FREERTOS_AF_INET6 : FREERTOS_AF_INET;
 		  Socket_t   socket =
@@ -512,7 +575,14 @@ Socket network_socket_create_and_bind(Timeout            *timeout,
 			  token_obj_destroy(mallocCapability, socket_key(), sealedSocket);
 			  return -ENOMEM;
 		  }
+
+		  /*
+		   * Create a bidirectional association between the FreeRTOS socket and
+		   * the sealed socket wrapper. This is used to retrieve the sealed
+		   * socket wrapper from the FreeRTOS socket in the callbacks.
+		   */
 		  socketWrapper->socket = socket;
+		  xSocketSetSocketID(socket, socketWrapper);
 
 		  // Claim the socket so that it counts towards the caller's quota.  The
 		  // network stack also keeps a claim to it.  We will drop this claim on
@@ -673,6 +743,24 @@ Socket network_socket_accept_tcp(Timeout            *timeout,
 			  token_obj_destroy(mallocCapability, socket_key(), sealedSocket);
 			  return acceptResult;
 		  }
+		  /*
+		   * Note that here we update the futex, but no need to call
+		   * notify_all() on the waiting threads. Because the threads are
+		   * waiting on multiwaiter for arriving connected socket, but here the
+		   * semantics is not having an arrving connection. So there is no need
+		   * to wake the threads up, since they will probably find that there is
+		   * no available sockets and go back to sleep again.
+		   */
+		  int futexConsumeResult = listeningSocket->consume_event_futex(
+		    SocketEventType::SocketAcceptEvent);
+		  if (futexConsumeResult != 0)
+		  {
+			  // Return -EINVAL, which represents the
+			  // socket will be freed soon.
+			  close_socket_retry(timeout, rawSocket);
+			  token_obj_destroy(mallocCapability, socket_key(), sealedSocket);
+			  return futexConsumeResult;
+		  }
 		  socketWrapper->socket = rawSocket;
 
 		  // Claim the socket so that it counts towards the caller's quota.  The
@@ -831,6 +919,37 @@ Socket network_socket_udp(Timeout            *timeout,
 	  timeout, mallocCapability, isIPv6, ConnectionTypeUDP);
 }
 
+/**
+ * Getter to get the read only capability of a specific futex in
+ * specific socket. If the futex is invalid, return a untagged nullptr.
+ */
+uint32_t *network_socket_get_event_source(Socket          sealedSocket,
+                                          SocketEventType type)
+{
+	uint32_t *result = nullptr;
+	if (type < NumFutexTypes)
+	{
+		with_sealed_socket(
+		  [&](SealedSocket *socket) {
+			  auto *futex =
+			    reinterpret_cast<uint32_t *>(&socket->eventFutexState[type]);
+
+			  Capability readyOnlyEventSource{futex};
+			  // Restrict the capability to read-only so the futex can only be
+			  // modified through the callback, not by the caller of this
+			  // helper.
+			  readyOnlyEventSource.bounds() = sizeof(uint32_t);
+			  readyOnlyEventSource.permissions() &=
+			    {Permission::Load, Permission::Global};
+
+			  result = readyOnlyEventSource.get();
+			  return 0;
+		  },
+		  sealedSocket);
+	}
+	return result;
+}
+
 int network_socket_close(Timeout            *t,
                          AllocatorCapability mallocCapability,
                          Socket              sealedSocket)
@@ -893,6 +1012,12 @@ int network_socket_close(Timeout            *t,
 			  if (socketEpoch == currentSocketEpoch.load())
 			  {
 				  bool isTCP = rawSocket->ucProtocol == FREERTOS_IPPROTO_TCP;
+
+				  // Set the back pointer (pointing to the
+				  // wrapper) to nullptr, so that we will not
+				  // have a dangling pointer.
+				  xSocketSetSocketID(rawSocket, nullptr);
+
 				  // Nothing to do if `FreeRTOS_shutdown`
 				  // fails: this happens only if the TCP
 				  // connection is dead, which is likely to
@@ -1039,6 +1164,14 @@ int network_socket_close(Timeout            *t,
 					  // task. With some luck, the socket can be
 					  // freed next time we try.
 					  return -ETIMEDOUT;
+				  }
+				  // Wake any thread waiting on this socket's event futex so
+				  // that it does not sleep forever on memory that is about to
+				  // be freed.
+				  for (auto &eventState : socket->eventFutexState)
+				  {
+					  eventState.store(SocketNotAvailable);
+					  eventState.notify_all();
 				  }
 
 				  g.release();

--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -460,12 +460,12 @@ int SealedSocket::signal_event_futex(SocketEventType type, int32_t count)
 	return -EINVAL;
 }
 /**
- * Wake send waiters when FreeRTOS reports that the TCP connection has closed.
+ * Wake waiters when FreeRTOS reports that the TCP connection has closed.
  * Preserve SocketNotAvailable if the socket wrapper is already being torn down.
  */
-void SealedSocket::mark_tcp_send_closed()
+void SealedSocket::mark_tcp_event_closed(SocketEventType type)
 {
-	auto &futex = eventFutexState[SocketEventType::SocketTCPSendEvent];
+	auto &futex = eventFutexState[type];
 	// This function will only be called from FreeRTOS callback,
 	// so the caller will not held the socket lock when calling this
 	// function. Thus, ephemeral call is needed to prevent Use-After-Free
@@ -578,11 +578,19 @@ static void on_tcp_connect(Socket_t socket, BaseType_t isConnected)
 		  static_cast<SealedSocket *>(pvSocketGetSocketID(socket));
 		if (wrapper != nullptr)
 		{
-			wrapper->mark_tcp_send_closed();
+			/*
+			 * Mark both events as closed and wake their waiters. The sentinel
+			 * prevents future waits from blocking on a connection that can no
+			 * longer be used.
+			 */
+			wrapper->mark_tcp_event_closed(SocketEventType::SocketTCPSendEvent);
+			wrapper->mark_tcp_event_closed(
+			  SocketEventType::SocketTCPConnectEvent);
 		}
 	}
 	else if (socket->u.xTCP.eTCPState == eTCP_LISTEN)
 	{
+		// A child connection is ready on this listening socket.
 		// Update eventFutexState in the listening socket and wake up the
 		// threads sleeping on the corresponding futex.
 		// Use the FreeRTOS getter to get the wrapper capability we stored in
@@ -598,6 +606,16 @@ static void on_tcp_connect(Socket_t socket, BaseType_t isConnected)
 			wrapper->signal_event_futex(SocketEventType::SocketAcceptEvent);
 		}
 		return;
+	}
+	else
+	{
+		// The outgoing client socket is now connected.
+		auto *wrapper =
+		  static_cast<SealedSocket *>(pvSocketGetSocketID(socket));
+		if (wrapper != nullptr)
+		{
+			wrapper->signal_event_futex(SocketEventType::SocketTCPConnectEvent);
+		}
 	}
 }
 F_TCP_UDP_Handler_t onTCPConnectCallback = {on_tcp_connect};
@@ -973,13 +991,20 @@ int network_socket_connect_tcp_internal(Timeout       *timeout,
 			  case -pdFREERTOS_ERRNO_EISCONN: // already connected
 				  Debug::log("Successfully connected to server");
 				  return 0;
+			  /*
+			   * EWOULDBLOCK means this call started the connection without
+			   * waiting. EINPROGRESS means an earlier call is still connecting.
+			   */
+			  case -pdFREERTOS_ERRNO_EWOULDBLOCK:
+			  case -pdFREERTOS_ERRNO_EINPROGRESS:
+				  Debug::log("Connection in progress");
+				  return -EINPROGRESS;
 			  /**
 			   * In certain cases, `FreeRTOS_connect` may return
 			   * -ENOTCONN if the connection times out. This is not
 			   *  publicly documented.
 			   */
 			  case -pdFREERTOS_ERRNO_ENOTCONN:
-			  case -pdFREERTOS_ERRNO_EWOULDBLOCK:
 			  case -pdFREERTOS_ERRNO_ETIMEDOUT:
 				  Debug::log("Timed out while connecting");
 				  return -ETIMEDOUT;

--- a/lib/tcpip/network_wrapper.cc
+++ b/lib/tcpip/network_wrapper.cc
@@ -415,7 +415,7 @@ namespace
 
 } // namespace
 
-int SealedSocket::signal_event_futex(SocketEventType type)
+int SealedSocket::signal_event_futex(SocketEventType type, int32_t count)
 {
 	auto &futex = eventFutexState[type];
 	if (heap_claim_ephemeral(TimeoutWaitForever, &futex) != 0)
@@ -423,15 +423,16 @@ int SealedSocket::signal_event_futex(SocketEventType type)
 		return -EINVAL;
 	}
 	int32_t current = futex.load();
-	while (current != SocketNotAvailable)
+	while ((current != SocketConnectionClosed) &&
+	       (current != SocketNotAvailable))
 	{
 		/*
 		 * If the futex's current value equals current,
-		 * store current + 1 and return true. Otherwise
+		 * store current + count and return true. Otherwise
 		 * write the actual current value into current
 		 * (by reference) and return false.
 		 */
-		if (futex.compare_exchange_strong(current, current + 1))
+		if (futex.compare_exchange_strong(current, current + count))
 		{
 			futex.notify_all();
 			return 0;
@@ -440,14 +441,41 @@ int SealedSocket::signal_event_futex(SocketEventType type)
 
 	return -EINVAL;
 }
+/**
+ * Wake send waiters when FreeRTOS reports that the TCP connection has closed.
+ * Preserve SocketNotAvailable if the socket wrapper is already being torn down.
+ */
+void SealedSocket::mark_tcp_send_closed()
+{
+	auto &futex = eventFutexState[SocketEventType::SocketTCPSendEvent];
+	// This function will only be called from FreeRTOS callback,
+	// so the caller will not held the socket lock when calling this
+	// function. Thus, ephemeral call is needed to prevent Use-After-Free
+	// issue.
+	if (heap_claim_ephemeral(TimeoutWaitForever, &futex) != 0)
+	{
+		return;
+	}
+	int32_t current = futex.load();
+	while ((current != SocketConnectionClosed) &&
+	       (current != SocketNotAvailable))
+	{
+		if (futex.compare_exchange_strong(current, SocketConnectionClosed))
+		{
+			futex.notify_all();
+			return;
+		}
+	}
+}
 
-int SealedSocket::consume_event_futex(SocketEventType type)
+int SealedSocket::consume_event_futex(SocketEventType type, int32_t count)
 {
 	auto   &futex   = eventFutexState[type];
 	int32_t current = futex.load();
-	while (current != SocketNotAvailable)
+	while ((current != SocketConnectionClosed) &&
+	       (current != SocketNotAvailable))
 	{
-		if (futex.compare_exchange_strong(current, current - 1))
+		if (futex.compare_exchange_strong(current, current - count))
 		{
 			return 0;
 		}
@@ -455,10 +483,29 @@ int SealedSocket::consume_event_futex(SocketEventType type)
 
 	return -EINVAL;
 }
+/**
+ * Callback called by FreeRTOS+TCP when TCP bytes are acknowledged.
+ *
+ * Add the acknowledged byte count to the send event futex and wake all threads
+ * waiting for txStream space.
+ */
+static void on_tcp_sent(Socket_t socket, size_t length)
+{
+	// Retrieve the wrapper from the back pointer.
+	auto *wrapper = static_cast<SealedSocket *>(pvSocketGetSocketID(socket));
+	if (wrapper != nullptr)
+	{
+		wrapper->signal_event_futex(SocketEventType::SocketTCPSendEvent,
+		                            static_cast<int32_t>(length));
+	}
+}
+F_TCP_UDP_Handler_t onTCPSentCallback = {nullptr, nullptr, on_tcp_sent};
 
 /**
  * Callback called by FreeRTOS+TCP when a TCP connection is created or
  * terminated.
+ *
+ * A terminated connection also wakes threads waiting for TCP send space.
  *
  * We use this callback to handle the case where a three-way TCP handshake
  * initiated by a peer on a listening socket fails.
@@ -509,8 +556,14 @@ static void on_tcp_connect(Socket_t socket, BaseType_t isConnected)
 			firewall_remove_tcpipv4_remote_endpoint(
 			  address.sin_address.ulIP_IPv4, localPort, address.sin_port);
 		}
+		auto *wrapper =
+		  static_cast<SealedSocket *>(pvSocketGetSocketID(socket));
+		if (wrapper != nullptr)
+		{
+			wrapper->mark_tcp_send_closed();
+		}
 	}
-	else
+	else if (socket->u.xTCP.eTCPState == eTCP_LISTEN)
 	{
 		// Update eventFutexState in the listening socket and wake up the
 		// threads sleeping on the corresponding futex.
@@ -664,13 +717,25 @@ Socket network_socket_create_and_bind(Timeout            *timeout,
 					    mallocCapability, socket_key(), sealedSocket);
 					  return -EAGAIN;
 				  }
-
+			  }
+			  if (type == ConnectionTypeTCP)
+			  {
 				  FreeRTOS_setsockopt(
 				    socket,
 				    0,
 				    FREERTOS_SO_TCP_CONN_HANDLER,
 				    static_cast<void *>(&onTCPConnectCallback),
 				    sizeof(onTCPConnectCallback));
+				  /*
+				   * Register the callback `on_tcp_sent()`
+				   * for sending bytes. This is to support
+				   * multiwaiter feature in network stack.
+				   */
+				  FreeRTOS_setsockopt(socket,
+				                      0,
+				                      FREERTOS_SO_TCP_SENT_HANDLER,
+				                      static_cast<void *>(&onTCPSentCallback),
+				                      sizeof(onTCPSentCallback));
 			  }
 		  }
 		  else
@@ -1421,14 +1486,37 @@ ssize_t network_socket_send(Timeout *timeout,
 		  {
 			  return -EPERM;
 		  }
+		  // Create the txStream and initialize send futex on the
+		  // first non-zero send.
+		  if ((length != 0) && (socket->socket->u.xTCP.txStream == nullptr))
+		  {
+			  if (FreeRTOS_get_tx_base(socket->socket) == nullptr)
+			  {
+				  // Allocation failed.
+				  return -ENOMEM;
+			  }
+			  // Store current available bytes to initialize the futex.
+			  auto &sendFutex =
+			    socket->eventFutexState[SocketEventType::SocketTCPSendEvent];
+			  int32_t uninitialized = 0;
+			  // The reason why we use compare_exchange_* here is that
+			  // if the socket is disconnected, a plain .store() would
+			  // overwrite SocketConnectionClosed.
+			  sendFutex.compare_exchange_strong(
+			    uninitialized, FreeRTOS_tx_space(socket->socket));
+		  }
 		  Debug::log("Sending {}-byte TCP packet from {}", length, buffer);
 		  int ret = with_freertos_timeout(
 		    timeout, socket->socket, FREERTOS_SO_SNDTIMEO, [&] {
 			    return FreeRTOS_send(socket->socket, buffer, length, 0);
 		    });
 		  Debug::log("FreeRTOS_send returned {}", ret);
+		  // Subtract the bytes queued by FreeRTOS_send() from the available
+		  // txStream space.
 		  if (ret >= 0)
 		  {
+			  socket->consume_event_futex(SocketEventType::SocketTCPSendEvent,
+			                              ret);
 			  return ret;
 		  }
 		  if (ret == -pdFREERTOS_ERRNO_ENOTCONN)

--- a/lib/tcpip/tcpip-internal.h
+++ b/lib/tcpip/tcpip-internal.h
@@ -49,7 +49,7 @@ struct SealedSocket
 	 * feature. Different events increment different futexes in the array and
 	 * wake the corresponding waiting threads.
 	 */
-	std::atomic<uint32_t> eventFutexState[NumFutexTypes];
+	std::atomic<int32_t> eventFutexState[NumFutexTypes];
 	/**
 	 * Increments the futex and notifies all waiters if the futex is still
 	 * valid.
@@ -58,16 +58,17 @@ struct SealedSocket
 	 */
 	int signal_event_futex(SocketEventType type);
 	/**
-	 * Consume one pending event by decrementing the futex.
+	 * Records one successfully accepted child socket by decrementing the accept
+	 * event counter.
 	 *
 	 * The caller must hold `socketLock`, which prevents the socket from being
-	 * deallocated while the futex is accessed. This operation is only
-	 * bookkeeping: the caller has already consumed the corresponding event, so
-	 * a zero counter is not an error.
+	 * freed while the futex is accessed. The futex value may become negative
+	 * if this helper is invoked after `FreeRTOS_accept()` successfully dequeue
+	 * a child, but before `on_tcp_connect()` increment the futex. The delayed
+	 * increment will repay this temporary debt.
 	 *
-	 * Returns 0 if the futex remains valid, regardless of whether the counter
-	 * was decremented. Returns `-EINVAL` if the futex has been invalidated by
-	 * being set to `SocketNotAvailable` because the socket is being torn down.
+	 * Returns 0 on success, or `-EINVAL` if the futex has been invalidated by
+	 * being set to `SocketNotAvailable`.
 	 */
 	int consume_event_futex(SocketEventType type);
 	/**

--- a/lib/tcpip/tcpip-internal.h
+++ b/lib/tcpip/tcpip-internal.h
@@ -51,6 +51,15 @@ struct SealedSocket
 	 */
 	std::atomic<int32_t> eventFutexState[NumFutexTypes];
 	/**
+	 * Initialize all event futexes for a given socket.
+	 * This should be called as long as a socket is created.
+	 * All futexes will be initialized to `0` to align with
+	 * the futexes semantics, except `SocketTCPSendEvent` futex.
+	 * It will be initialized to pre-configured txStream buffer
+	 * size to prevent indefinite blocking thread.
+	 */
+	void initialize_event_futexes();
+	/**
 	 * Increments the futex by `count` and notifies all waiters if the futex is
 	 * still valid.
 	 *

--- a/lib/tcpip/tcpip-internal.h
+++ b/lib/tcpip/tcpip-internal.h
@@ -51,15 +51,20 @@ struct SealedSocket
 	 */
 	std::atomic<int32_t> eventFutexState[NumFutexTypes];
 	/**
-	 * Increments the futex and notifies all waiters if the futex is still
-	 * valid.
+	 * Increments the futex by `count` and notifies all waiters if the futex is
+	 * still valid.
 	 *
-	 * Returns 0 on success, or `-EINVAL` if the futex has been invalidated.
+	 * Returns 0 on success, or `-EINVAL` if the futex has been set to a
+	 * terminal value.
 	 */
-	int signal_event_futex(SocketEventType type);
+	int signal_event_futex(SocketEventType type, int32_t count = 1);
 	/**
-	 * Records one successfully accepted child socket by decrementing the accept
-	 * event counter.
+	 * Marks the TCP send event futex as closed and notifies all waiters.
+	 */
+	void mark_tcp_send_closed();
+	/**
+	 * Records successfully consumed events by decrementing the event counter by
+	 * `count`.
 	 *
 	 * The caller must hold `socketLock`, which prevents the socket from being
 	 * freed while the futex is accessed. The futex value may become negative
@@ -67,10 +72,10 @@ struct SealedSocket
 	 * a child, but before `on_tcp_connect()` increment the futex. The delayed
 	 * increment will repay this temporary debt.
 	 *
-	 * Returns 0 on success, or `-EINVAL` if the futex has been invalidated by
-	 * being set to `SocketNotAvailable`.
+	 * Returns 0 on success, or `-EINVAL` if the futex has been set to a
+	 * terminal value.
 	 */
-	int consume_event_futex(SocketEventType type);
+	int consume_event_futex(SocketEventType type, int32_t count = 1);
 	/**
 	 * The lock protecting this socket.
 	 */

--- a/lib/tcpip/tcpip-internal.h
+++ b/lib/tcpip/tcpip-internal.h
@@ -3,6 +3,8 @@
 
 #pragma once
 #include <FreeRTOS_IP.h>
+#include <NetAPI.h>
+#include <atomic>
 #include <ds/linked_list.h>
 #include <function_wrapper.hh>
 #include <locks.hh>
@@ -42,6 +44,14 @@ struct SealedSocket
 	 * to the current instance of the network stack.
 	 */
 	uint64_t socketEpoch;
+	/**
+	 * Event waiter source futex array. This supports the multi-waiter
+	 * feature. Different events increment different futexes in the array and
+	 * wake the corresponding waiting threads.
+	 */
+	std::atomic<uint32_t> eventFutexState[NumFutexTypes];
+	int                   signal_event_futex(SocketEventType type);
+	int                   consume_event_futex(SocketEventType type);
 	/**
 	 * The lock protecting this socket.
 	 */

--- a/lib/tcpip/tcpip-internal.h
+++ b/lib/tcpip/tcpip-internal.h
@@ -68,9 +68,9 @@ struct SealedSocket
 	 */
 	int signal_event_futex(SocketEventType type, int32_t count = 1);
 	/**
-	 * Marks the TCP send event futex as closed and notifies all waiters.
+	 * Marks a TCP event futex as closed and notifies all waiters.
 	 */
-	void mark_tcp_send_closed();
+	void mark_tcp_event_closed(SocketEventType type);
 	/**
 	 * Records successfully consumed events by decrementing the event counter by
 	 * `count`.

--- a/lib/tcpip/tcpip-internal.h
+++ b/lib/tcpip/tcpip-internal.h
@@ -50,8 +50,26 @@ struct SealedSocket
 	 * wake the corresponding waiting threads.
 	 */
 	std::atomic<uint32_t> eventFutexState[NumFutexTypes];
-	int                   signal_event_futex(SocketEventType type);
-	int                   consume_event_futex(SocketEventType type);
+	/**
+	 * Increments the futex and notifies all waiters if the futex is still
+	 * valid.
+	 *
+	 * Returns 0 on success, or `-EINVAL` if the futex has been invalidated.
+	 */
+	int signal_event_futex(SocketEventType type);
+	/**
+	 * Consume one pending event by decrementing the futex.
+	 *
+	 * The caller must hold `socketLock`, which prevents the socket from being
+	 * deallocated while the futex is accessed. This operation is only
+	 * bookkeeping: the caller has already consumed the corresponding event, so
+	 * a zero counter is not an error.
+	 *
+	 * Returns 0 if the futex remains valid, regardless of whether the counter
+	 * was decremented. Returns `-EINVAL` if the futex has been invalidated by
+	 * being set to `SocketNotAvailable` because the socket is being torn down.
+	 */
+	int consume_event_futex(SocketEventType type);
 	/**
 	 * The lock protecting this socket.
 	 */

--- a/lib/tcpip/tcpip_error_handler.h
+++ b/lib/tcpip/tcpip_error_handler.h
@@ -195,6 +195,13 @@ extern "C" void reset_network_stack_state(bool isIpThread)
 				DebugErrorHandler::log("Ignoring corrupted socket lock {}.",
 				                       lock);
 			}
+			// Notify all threads waiting on the socket's futexes so that they
+			// do not sleep forever on this old socket.
+			for (auto &eventState : socket->eventFutexState)
+			{
+				eventState.store(SocketNotAvailable);
+				eventState.notify_all();
+			}
 
 			FreeRTOS_Socket_t *s = socket->socket;
 			if (Capability{s}.is_valid() &&


### PR DESCRIPTION
Add a TCP connect event so one thread can start several outgoing TCP
connections and wait for any of them to finish.

### Workflow:
The caller first calls `network_socket_connect_tcp_internal()` with a zero
timeout. FreeRTOS starts the handshake and returns `-EWOULDBLOCK` immediately
because it cannot wait. The caller waits on the multiwaiter until with expected
futex value equals to 0. When the connection succeeds, FreeRTOS will call
`on_tcp_connect()` which changes the futex to 1 and wakes all waiters. The caller
then retries the connect with a zero timeout and FreeRTOS returns `-EISCONN`.
The event stays one while the socket is connected. If the connection fails or
later closes, the callback changes the event to `SocketConnectionClosed` and wakes
all waiters.

### Key changes:
- Add `SocketTCPConnectEvent`: 0 means not connected and 1 means connected.
- In `network_socket_connect_tcp_internal()`. Handle `-EWOULDBLOCK` and
  `-EINPROGRESS` cases in switch. `-EWOULDBLOCK` means we call `FreeRTOS_connect`
  without non-zero timeout, while `-EINPROGRESS` means the connection is in
  progress, but not finished.
- When a TCP connection succeeds, signal the connect futex in `on_tcp_connect`.
- Set the connect event to `SocketConnectionClosed` and wake its waiters when
  the connection terminates.
